### PR TITLE
Scatter Simulation in SIRF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -226,7 +226,7 @@ before_install:
  - BUILD_FLAGS="$BUILD_FLAGS -DPYVER=$PYMVER -DSIRF_URL=$PWD -DSIRF_TAG=$TRAVIS_COMMIT"
  # get SuperBuild
  - cd ..
- - git clone https://github.com/CCPPETMR/SIRF-SuperBuild --recursive -b master
+ - git clone https://github.com/NikEfth/SIRF-SuperBuild --recursive -b point_2_Scatter_simulation
  - cd SIRF-SuperBuild
  - cmake --version
 

--- a/examples/Python/PET/scatter_simulation.py
+++ b/examples/Python/PET/scatter_simulation.py
@@ -1,0 +1,165 @@
+'''Scatter simulation demo: creates an image, projects it to simulate
+acquisition data and runs a scatter simulation
+
+Usage:
+  scatter_simulation [--help | options]
+
+Options:
+  -f <file>, --file=<file>    raw data file [default: Utahscat600k_ca_seg4.hs]
+  -p <path>, --path=<path>    path to data files, defaults to data/examples/PET
+                              subfolder of SIRF root folder
+  -a <addv>, --addv=<addv>    additive term value [default: 0]
+  -b <back>, --back=<back>    background term value [default: 0]
+  -n <norm>, --norm=<norm>    normalization value [default: 1]
+  -o <file>, --output=<file>  output file for simulated data
+  -e <engn>, --engine=<engn>  reconstruction engine [default: STIR]
+
+There is an interactive demo with much more documentation on this process.
+You probably want to check that instead.
+'''
+
+## CCP PETMR Synergistic Image Reconstruction Framework (SIRF)
+## Copyright 2015 - 2017 Rutherford Appleton Laboratory STFC
+## Copyright 2015 - 2018 University College London.
+##
+## This is software developed for the Collaborative Computational
+## Project in Positron Emission Tomography and Magnetic Resonance imaging
+## (http://www.ccppetmr.ac.uk/).
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+##   you may not use this file except in compliance with the License.
+##   You may obtain a copy of the License at
+##       http://www.apache.org/licenses/LICENSE-2.0
+##   Unless required by applicable law or agreed to in writing, software
+##   distributed under the License is distributed on an "AS IS" BASIS,
+##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##   See the License for the specific language governing permissions and
+##   limitations under the License.
+
+__version__ = '0.1.0'
+from docopt import docopt
+args = docopt(__doc__, version=__version__)
+
+# import engine module
+exec('from sirf.' + args['--engine'] + ' import *')
+
+from pUtilities import show_2D_array
+
+# import engine module
+exec('from sirf.' + args['--engine'] + ' import *')
+
+# process command-line options
+data_file = args['--file']
+data_path = args['--path']
+if data_path is None:
+    data_path = examples_data_path('PET')
+raw_data_file = existing_filepath(data_path, data_file)
+addv = float(args['--addv'])
+back = float(args['--back'])
+beff = 1/float(args['--norm'])
+output_file = args['--output']
+
+def main():
+
+##    AcquisitionData.set_storage_scheme('mem')
+
+    # no info printing from the engine, warnings and errors sent to stdout
+    msg_red = MessageRedirector()
+    # output goes to files
+##    msg_red = MessageRedirector('info.txt', 'warn.txt', 'errr.txt')
+
+    # create an empty image
+    image = ImageData()
+    image_size = (31, 111, 111)
+    voxel_size = (3.375, 3, 3) # voxel sizes are in mm
+    image.initialise(image_size, voxel_size)
+
+    # create a shape
+    shape = EllipticCylinder()
+    shape.set_length(400)
+    shape.set_radii((40, 100))
+    shape.set_origin((10, 60, 0))
+
+    # add the shape to the image
+    image.add_shape(shape, scale = 1)
+
+    # add another shape
+    shape.set_radii((30, 30))
+    shape.set_origin((10, -30, 60))
+    image.add_shape(shape, scale = 1.5)
+
+    # add another shape
+    shape.set_origin((10, -30, -60))
+    image.add_shape(shape, scale = 0.75)
+
+    # z-pixel coordinate of the xy-crossection to show
+    z = int(image_size[0]/2)
+
+    # show the phantom image
+    image_array = image.as_array()
+    show_2D_array('Phantom image', image_array[z,:,:])
+
+    sss = SingleScatterSimulator()
+
+
+
+    # raw data to be used as a template for the acquisition model
+    acq_template = AcquisitionData(raw_data_file)
+
+    # select acquisition model that implements the geometric
+    # forward projection by a ray tracing matrix multiplication
+    acq_model = AcquisitionModelUsingRayTracingMatrix()
+
+    # testing bin efficiencies
+    bin_eff = acq_template.clone()
+    bin_eff.fill(beff)
+    bin_eff_arr = bin_eff.as_array()
+    # As an example, if bin efficiencies are non-trivial, set a portion of them to zero;
+    # this should zero the corresponding portion of forward projection
+    # and 'damage' the backprojection making it look less like the
+    # actual image
+    if beff != 1:
+        bin_eff_arr[0,:,10:50,:] = 0
+    show_2D_array('Bin efficiencies', bin_eff_arr[0,0,:,:])
+    bin_eff.fill(bin_eff_arr)
+
+    asm = AcquisitionSensitivityModel(bin_eff)
+    acq_model.set_acquisition_sensitivity(asm)
+
+    # As an example, add both an additive term and background term
+    # (you normally wouldn't do this for real data)
+    add = acq_template.clone()
+    add.fill(addv)
+    acq_model.set_additive_term(add)
+
+    bck = acq_template.clone()
+    bck.fill(back)
+    acq_model.set_background_term(bck)
+
+    print('projecting image...')
+    # project the image to obtain simulated acquisition data
+    # data from raw_data_file is used as a template
+    acq_model.set_up(acq_template, image)
+    simulated_data = acq_template.get_uniform_copy()
+    acq_model.forward(image, 0, 4, simulated_data)
+#    simulated_data = acq_model.forward(image, 0, 4)
+    if output_file is not None:
+        simulated_data.write(output_file)
+
+    # show simulated acquisition data
+    simulated_data_as_array = simulated_data.as_array()
+    show_2D_array('Forward projection', simulated_data_as_array[0,0,:,:])
+
+    print('backprojecting the forward projection...')
+    # backproject the computed forward projection
+    # note that the backprojection takes the acquisition sensitivy model asm into account as well
+    back_projected_image = acq_model.backward(simulated_data, 0, 4)
+
+    back_projected_image_as_array = back_projected_image.as_array()
+    show_2D_array('Backprojection', back_projected_image_as_array[z,:,:])
+
+try:
+    main()
+    print('done')
+except error as err:
+    print('%s' % err.value)

--- a/examples/Python/PET/scatter_simulation.py
+++ b/examples/Python/PET/scatter_simulation.py
@@ -70,10 +70,6 @@ def main():
 
     # Create a template Acquisition Model
     tmpl_acq_data = AcquisitionData('ECAT 931', 1, 0, 1)
-    sss = SingleScatterSimulator()
-
-    # Input in the Simulator information about the Acquisition
-    sss.set_Acquisition_template(tmpl_acq_data)
 
     # create the attenuation image
     atten_image = ImageData(tmpl_acq_data)
@@ -119,39 +115,24 @@ def main():
     act_image_array = act_image.as_array()
     show_2D_array('Activity image', act_image_array[z, :, :])
 
-    # Crete the Single Scatter Simulation model
+    # Create the Single Scatter Simulation model
+    sss = SingleScatterSimulator()
 
+    # Input in the Simulator information about the Acquisition
+    sss.set_acquisition_data(tmpl_acq_data)
 
-    # Check if the Acquisition template was set properly
-    if not sss.has_Acquisition_template():
-        sys.exit('Could not set the acquisition template')
+    # Set the attenuation image
+    sss.set_attenuation_image(atten_image)
 
-    if not sss.has_Scanner_with_Energy_info():
-        print("Please remember to set up the scanner energy resolution and reference energy.\n " \
-              "In this example I will set it for you to 35% :-)")
-        assert isinstance(sss, SingleScatterSimulator)
-        sss.set_energy_resolution(0.15)
-        en_res = sss.get_energy_resolution()
-        print("The energy resolution of the scanner is: ", str(en_res))
-    else:
-        en_res = sss.get_energy_resolution()
-        print("The energy resolution of the scanner is: ", str(en_res))
+    # Set the activity image
+    sss.set_activity_image(act_image)
 
-    if not sss.has_energy_window():
-        le = 450.0
-        he = 650.0
-        print('The energy window has not been set-up. In this example I will set it up for you'
-              'at ', str(le), ' keV to ', str(he), ' keV.')
-        sss.set_low_energy_threshold(le)
-        sss.set_high_energy_threshold(he)
-        print("The energy window is set from ",
-              sss.get_low_energy_threshold(),
-              " keV to ", sss.get_high_energy_threshold(), " keV.")
-    else:
-        print("The energy window is set from ",
-              sss.get_low_energy_threshold(),
-              " keV to ", sss.get_high_energy_threshold(), " keV.")
+    # At last call set_up()
+    output_data = sss.set_up()
 
+    # sss.simulate()
+
+    # sss_data = sss.get_output()
 
     debug_stop = 0
 

--- a/src/iUtilities/iutilities.cpp
+++ b/src/iUtilities/iutilities.cpp
@@ -73,6 +73,10 @@ extern "C" {
 	{
 		return charDataFromDataHandle((const DataHandle*)ptr);
 	}
+    bool boolDataFromHandle(const void* ptr)
+    {
+        return dataFromHandle<bool>(ptr);
+    }
 	int intDataFromHandle(const void* ptr)
 	{
 		return dataFromHandle<int>(ptr);

--- a/src/iUtilities/iutilities.h
+++ b/src/iUtilities/iutilities.h
@@ -30,6 +30,7 @@ extern "C" {
 	void* floatDataHandle(float i);
 	void* doubleDataHandle(double i);
 	char* charDataFromHandle(const void* ptr);
+    bool boolDataFromHandle(const void* ptr);
 	int intDataFromHandle(const void* ptr);
 	int intDataItemFromHandle(const void* ptr, int i);
 	int uint16DataItemFromHandle(const void* ptr, int i);

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -1073,3 +1073,18 @@ void* cSTIR_setImageData(const void* ptr_im, size_t ptr_data)
 	}
 	CATCH;
 }
+
+extern "C"
+void* cSTIR_setupSingleScatterSimulation(void* ptr_r)
+{
+    try {
+        DataHandle* handle = new DataHandle;
+        SingleScatterSimulation& sss =
+            objectFromHandle< SingleScatterSimulation >(ptr_r);
+        if (sss.set_up() != Succeeded::yes) {
+            //TODO
+        }
+        return (void*)handle;
+    }
+    CATCH;
+}

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -87,6 +87,8 @@ void* cSTIR_newObject(const char* name)
 			return NEW_OBJECT_HANDLE(CylindricFilter3DF);
 		if (boost::iequals(name, "EllipsoidalCylinder"))
 			return NEW_OBJECT_HANDLE(EllipsoidalCylinder);
+        if (boost::iequals(name, "PETSingleScatterSimulation"))
+            return NEW_OBJECT_HANDLE(PETSingleScatterSimulation);
 		return unknownObject("object", name, __FILE__, __LINE__);
 	}
 	CATCH;
@@ -212,6 +214,11 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 				sptr(new ListmodeToSinograms(filename));
 			return newObjectHandle(sptr);
 		}
+        if (boost::iequals(name, "PETSingleScatterSimulation")) {
+            shared_ptr<PETSingleScatterSimulation>
+                sptr(new PETSingleScatterSimulation(filename));
+            return newObjectHandle(sptr);
+        }
 		return unknownObject("object", name, __FILE__, __LINE__);
 	}
 	CATCH;

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -87,8 +87,8 @@ void* cSTIR_newObject(const char* name)
 			return NEW_OBJECT_HANDLE(CylindricFilter3DF);
 		if (boost::iequals(name, "EllipsoidalCylinder"))
 			return NEW_OBJECT_HANDLE(EllipsoidalCylinder);
-        if (boost::iequals(name, "PETSingleScatterSimulation"))
-            return NEW_OBJECT_HANDLE(PETSingleScatterSimulation);
+        if (boost::iequals(name, "SingleScatterSimulation"))
+            return NEW_OBJECT_HANDLE(SingleScatterSimulation);
 		return unknownObject("object", name, __FILE__, __LINE__);
 	}
 	CATCH;
@@ -107,6 +107,8 @@ void* cSTIR_setParameter
 			return cSTIR_setShapeParameter(ptr_s, name, ptr_v);
 		else if (boost::iequals(obj, "EllipsoidalCylinder"))
 			return cSTIR_setEllipsoidalCylinderParameter(hs, name, hv);
+        else if (boost::iequals(obj, "SingleScatterSimulation"))
+            return cSTIR_setSingleScatterSimulationParameter(hs, name, hv);
 		else if (boost::iequals(obj, "TruncateToCylindricalFOVImageProcessor"))
 			return cSTIR_setTruncateToCylindricalFOVImageProcessorParameter
 			(hs, name, hv);
@@ -164,6 +166,8 @@ void* cSTIR_parameter(const void* ptr, const char* obj, const char* name)
 			return cSTIR_rayTracingMatrixParameter(handle, name);
 		else if (boost::iequals(obj, "AcqModUsingMatrix"))
 			return cSTIR_acqModUsingMatrixParameter(handle, name);
+        else if (boost::iequals(obj, "SingleScatterSimulation"))
+            return cSTIR_SingleScatterSimulationParameter(handle, name);
 		else if (boost::iequals(obj, "GeneralisedPrior"))
 			return cSTIR_generalisedPriorParameter(handle, name);
 		else if (boost::iequals(obj, "PLSPrior"))
@@ -214,9 +218,9 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 				sptr(new ListmodeToSinograms(filename));
 			return newObjectHandle(sptr);
 		}
-        if (boost::iequals(name, "PETSingleScatterSimulation")) {
-            shared_ptr<PETSingleScatterSimulation>
-                sptr(new PETSingleScatterSimulation(filename));
+        if (boost::iequals(name, "SingleScatterSimulation")) {
+            shared_ptr<SingleScatterSimulation>
+                sptr(new SingleScatterSimulation(filename));
             return newObjectHandle(sptr);
         }
 		return unknownObject("object", name, __FILE__, __LINE__);

--- a/src/xSTIR/cSTIR/cstir.h
+++ b/src/xSTIR/cSTIR/cstir.h
@@ -137,6 +137,8 @@ extern "C" {
 	void* deleteTextPrinter(void* ptr);
 	void* deleteTextWriter(void* ptr_w);
 
+    //Scatter related methods
+    void* cSTIR_setupSingleScatterSimulation(void* ptr_r);
 #ifndef CSTIR_FOR_MATLAB
 }
 #endif

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -159,11 +159,36 @@ sirf::cSTIR_setSingleScatterSimulationParameter
         PETAcquisitionData& o = objectFromHandle<PETAcquisitionData>(hv);
         shared_ptr< ProjDataInfo> obj_sptr = o.get_proj_data_info_sptr();
         c.set_template_proj_data_info_sptr(obj_sptr);
+
+        shared_ptr< ExamInfo> obj_sptr2 = o.get_exam_info_sptr();
+        c.set_exam_info_sptr(obj_sptr2);
     }
-//    else if (boost::iequals(name, "radius_x"))
-//    {
-//        c.set_radius_x(value);
-//    }
+    else if (boost::iequals(name, "set_Scanner_energy_information"))
+    {
+        float arg = dataFromHandle<float>(hv);
+        if(!is_null_ptr(c.get_template_proj_data_info_sptr()))
+        {
+            c.get_template_proj_data_info_sptr()->get_scanner_sptr()->set_energy_resolution(arg);
+            c.get_template_proj_data_info_sptr()->get_scanner_sptr()->set_reference_energy(511.f);
+        }
+    }
+    else if (boost::iequals(name, "low_energy_threshold"))
+    {
+        float arg = dataFromHandle<float>(hv);
+        if(!is_null_ptr(c.get_ExamInfo_sptr()))
+        {
+            c.get_ExamInfo_sptr()->set_low_energy_thres(arg);
+        }
+    }
+    else if (boost::iequals(name, "high_energy_threshold"))
+    {
+        float arg = dataFromHandle<float>(hv);
+        if(!is_null_ptr(c.get_ExamInfo_sptr()))
+        {
+            c.get_ExamInfo_sptr()->set_high_energy_thres(arg);
+        }
+    }
+
 //    else if (boost::iequals(name, "radius_y"))
 //    {
 //        c.set_radius_y(value);
@@ -202,8 +227,49 @@ sirf::cSTIR_SingleScatterSimulationParameter(const DataHandle* handle, const cha
     }
     else if(boost::iequals(name, "has_template_proj_data_info"))
     {
-        return  dataHandle<bool>(!c.has_template_proj_data_info());
+        return  dataHandle<bool>(c.has_template_proj_data_info());
     }
+    else if (boost::iequals(name, "has_Scanner_with_energy_information"))
+    {
+        if (!is_null_ptr(c.get_template_proj_data_info_sptr()))
+            return  dataHandle<bool>(c.get_template_proj_data_info_sptr()->has_energy_information());
+        else
+            return dataHandle<bool>(false);
+    }
+    else if (boost::iequals(name, "get_energy_resolution"))
+    {
+        if (!is_null_ptr(c.get_template_proj_data_info_sptr()))
+            return  dataHandle<float>(c.get_template_proj_data_info_sptr()->get_scanner_sptr()->get_energy_resolution());
+        else
+            return dataHandle<float>(-1.f);
+    }
+    else if (boost::iequals(name, "has_energy_window"))
+    {
+        if (!is_null_ptr(c.get_ExamInfo_sptr()))
+            return  dataHandle<bool>(c.get_ExamInfo_sptr()->has_energy_information());
+        else
+            return dataHandle<bool>(false);
+    }
+    else if (boost::iequals(name, "low_energy_threshold"))
+    {
+        if (!is_null_ptr(c.get_ExamInfo_sptr()))
+            return  dataHandle<float>(c.get_ExamInfo_sptr()->get_low_energy_thres());
+        else
+            return dataHandle<bool>(-1.0);
+    }
+    else if (boost::iequals(name, "high_energy_threshold"))
+    {
+        if (!is_null_ptr(c.get_ExamInfo_sptr()))
+            return  dataHandle<float>(c.get_ExamInfo_sptr()->get_high_energy_thres());
+        else
+            return dataHandle<bool>(-1.0);
+    }
+
+
+//    else if (boost::iequals(name, "has_ExamInfo_with_energy_information"))
+//    {
+//        return  dataHandle<bool>(!am.has_ExamInfo_with_energy_information());
+//    }
 
     return parameterNotFound(name, __FILE__, __LINE__);
 }

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -154,7 +154,7 @@ sirf::cSTIR_setSingleScatterSimulationParameter
     SingleScatterSimulation& c =
         objectFromHandle<SingleScatterSimulation>(hp);
 
-    if (boost::iequals(name, "template_proj_data_info"))
+    if (boost::iequals(name, "set_acquisition_data"))
     {
         PETAcquisitionData& o = objectFromHandle<PETAcquisitionData>(hv);
         shared_ptr< ProjDataInfo> obj_sptr = o.get_proj_data_info_sptr();
@@ -163,41 +163,40 @@ sirf::cSTIR_setSingleScatterSimulationParameter
         shared_ptr< ExamInfo> obj_sptr2 = o.get_exam_info_sptr();
         c.set_exam_info_sptr(obj_sptr2);
     }
-    else if (boost::iequals(name, "set_Scanner_energy_information"))
+    else if (boost::iequals(name, "set_activity_image"))
     {
-        float arg = dataFromHandle<float>(hv);
-        if(!is_null_ptr(c.get_template_proj_data_info_sptr()))
-        {
-            c.get_template_proj_data_info_sptr()->get_scanner_sptr()->set_energy_resolution(arg);
-            c.get_template_proj_data_info_sptr()->get_scanner_sptr()->set_reference_energy(511.f);
-        }
+        SPTR_FROM_HANDLE(Image3DF, image_sptr, hv);
+        c.set_activity_image_sptr(image_sptr);
     }
-    else if (boost::iequals(name, "low_energy_threshold"))
+    else if (boost::iequals(name, "set_attenuation_image"))
     {
-        float arg = dataFromHandle<float>(hv);
-        if(!is_null_ptr(c.get_ExamInfo_sptr()))
-        {
-            c.get_ExamInfo_sptr()->set_low_energy_thres(arg);
-        }
+        SPTR_FROM_HANDLE(Image3DF, image_sptr, hv);
+        c.set_density_image_sptr(image_sptr);
     }
-    else if (boost::iequals(name, "high_energy_threshold"))
-    {
-        float arg = dataFromHandle<float>(hv);
-        if(!is_null_ptr(c.get_ExamInfo_sptr()))
-        {
-            c.get_ExamInfo_sptr()->set_high_energy_thres(arg);
-        }
-    }
-
-//    else if (boost::iequals(name, "radius_y"))
-//    {
-//        c.set_radius_y(value);
-//    }
     else
     {
         return parameterNotFound(name, __FILE__, __LINE__);
     }
     return new DataHandle;
+}
+
+void*
+sirf::cSTIR_SingleScatterSimulationParameter(const DataHandle* handle, const char* name)
+{
+    SingleScatterSimulation& c =
+        objectFromHandle<SingleScatterSimulation>(handle);
+
+    // Reserved for get output
+    if (boost::iequals(name, "template_proj_data_info"))
+    {
+//        return dataHandle<float>(c.get_length());
+    }
+//    else if (boost::iequals(name, "has_ExamInfo_with_energy_information"))
+//    {
+//        return  dataHandle<bool>(!am.has_ExamInfo_with_energy_information());
+//    }
+
+    return parameterNotFound(name, __FILE__, __LINE__);
 }
 
 
@@ -213,65 +212,6 @@ sirf::cSTIR_ellipsoidalCylinderParameter(const DataHandle* handle, const char* n
 	if (boost::iequals(name, "radius_y"))
 		return dataHandle<float>(c.get_radius_y());
 	return parameterNotFound(name, __FILE__, __LINE__);
-}
-
-void*
-sirf::cSTIR_SingleScatterSimulationParameter(const DataHandle* handle, const char* name)
-{
-    SingleScatterSimulation& c =
-        objectFromHandle<SingleScatterSimulation>(handle);
-
-    if (boost::iequals(name, "template_proj_data_info"))
-    {
-//        return dataHandle<float>(c.get_length());
-    }
-    else if(boost::iequals(name, "has_template_proj_data_info"))
-    {
-        return  dataHandle<bool>(c.has_template_proj_data_info());
-    }
-    else if (boost::iequals(name, "has_Scanner_with_energy_information"))
-    {
-        if (!is_null_ptr(c.get_template_proj_data_info_sptr()))
-            return  dataHandle<bool>(c.get_template_proj_data_info_sptr()->has_energy_information());
-        else
-            return dataHandle<bool>(false);
-    }
-    else if (boost::iequals(name, "get_energy_resolution"))
-    {
-        if (!is_null_ptr(c.get_template_proj_data_info_sptr()))
-            return  dataHandle<float>(c.get_template_proj_data_info_sptr()->get_scanner_sptr()->get_energy_resolution());
-        else
-            return dataHandle<float>(-1.f);
-    }
-    else if (boost::iequals(name, "has_energy_window"))
-    {
-        if (!is_null_ptr(c.get_ExamInfo_sptr()))
-            return  dataHandle<bool>(c.get_ExamInfo_sptr()->has_energy_information());
-        else
-            return dataHandle<bool>(false);
-    }
-    else if (boost::iequals(name, "low_energy_threshold"))
-    {
-        if (!is_null_ptr(c.get_ExamInfo_sptr()))
-            return  dataHandle<float>(c.get_ExamInfo_sptr()->get_low_energy_thres());
-        else
-            return dataHandle<bool>(-1.0);
-    }
-    else if (boost::iequals(name, "high_energy_threshold"))
-    {
-        if (!is_null_ptr(c.get_ExamInfo_sptr()))
-            return  dataHandle<float>(c.get_ExamInfo_sptr()->get_high_energy_thres());
-        else
-            return dataHandle<bool>(-1.0);
-    }
-
-
-//    else if (boost::iequals(name, "has_ExamInfo_with_energy_information"))
-//    {
-//        return  dataHandle<bool>(!am.has_ExamInfo_with_energy_information());
-//    }
-
-    return parameterNotFound(name, __FILE__, __LINE__);
 }
 
 void*

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -148,6 +148,35 @@ sirf::cSTIR_setEllipsoidalCylinderParameter
 }
 
 void*
+sirf::cSTIR_setSingleScatterSimulationParameter
+(DataHandle* hp, const char* name, const DataHandle* hv)
+{
+    SingleScatterSimulation& c =
+        objectFromHandle<SingleScatterSimulation>(hp);
+
+    if (boost::iequals(name, "template_proj_data_info"))
+    {
+        PETAcquisitionData& o = objectFromHandle<PETAcquisitionData>(hv);
+        shared_ptr< ProjDataInfo> obj_sptr = o.get_proj_data_info_sptr();
+        c.set_template_proj_data_info_sptr(obj_sptr);
+    }
+//    else if (boost::iequals(name, "radius_x"))
+//    {
+//        c.set_radius_x(value);
+//    }
+//    else if (boost::iequals(name, "radius_y"))
+//    {
+//        c.set_radius_y(value);
+//    }
+    else
+    {
+        return parameterNotFound(name, __FILE__, __LINE__);
+    }
+    return new DataHandle;
+}
+
+
+void*
 sirf::cSTIR_ellipsoidalCylinderParameter(const DataHandle* handle, const char* name)
 {
 	EllipsoidalCylinder& c =
@@ -159,6 +188,24 @@ sirf::cSTIR_ellipsoidalCylinderParameter(const DataHandle* handle, const char* n
 	if (boost::iequals(name, "radius_y"))
 		return dataHandle<float>(c.get_radius_y());
 	return parameterNotFound(name, __FILE__, __LINE__);
+}
+
+void*
+sirf::cSTIR_SingleScatterSimulationParameter(const DataHandle* handle, const char* name)
+{
+    SingleScatterSimulation& c =
+        objectFromHandle<SingleScatterSimulation>(handle);
+
+    if (boost::iequals(name, "template_proj_data_info"))
+    {
+//        return dataHandle<float>(c.get_length());
+    }
+    else if(boost::iequals(name, "has_template_proj_data_info"))
+    {
+        return  dataHandle<bool>(!c.has_template_proj_data_info());
+    }
+
+    return parameterNotFound(name, __FILE__, __LINE__);
 }
 
 void*

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir_p.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir_p.h
@@ -38,15 +38,13 @@ namespace sirf {
 		cSTIR_setEllipsoidalCylinderParameter
 		(DataHandle* hp, const char* name, const DataHandle* hv);
 
-    void*
-        cSTIR_setSingleScatterSimulationParameter
-        (DataHandle* hp, const char* name, const DataHandle* hv);
-
 	void*
 		cSTIR_ellipsoidalCylinderParameter(const DataHandle* handle, const char* name);
 
     void*
-    cSTIR_SingleScatterSimulationParameter(const DataHandle* handle, const char* name);
+        cSTIR_setSingleScatterSimulationParameter(DataHandle* hp, const char* name, const DataHandle* hv);
+    void*
+       cSTIR_SingleScatterSimulationParameter(const DataHandle* handle, const char* name);
 
 	void*
 		cSTIR_setRayTracingMatrixParameter

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir_p.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir_p.h
@@ -38,8 +38,15 @@ namespace sirf {
 		cSTIR_setEllipsoidalCylinderParameter
 		(DataHandle* hp, const char* name, const DataHandle* hv);
 
+    void*
+        cSTIR_setSingleScatterSimulationParameter
+        (DataHandle* hp, const char* name, const DataHandle* hv);
+
 	void*
 		cSTIR_ellipsoidalCylinderParameter(const DataHandle* handle, const char* name);
+
+    void*
+    cSTIR_SingleScatterSimulationParameter(const DataHandle* handle, const char* name);
 
 	void*
 		cSTIR_setRayTracingMatrixParameter

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -193,17 +193,17 @@ namespace sirf {
 			_data = data;
 		}
 
-        inline bool has_Scanner_with_energy_information() const
+        void set_low_energy_threshold(float arg)
         {
-            return this->_data->get_proj_data_info_sptr()->get_scanner_sptr()->has_energy_information();
+            get_exam_info_sptr()->set_low_energy_thres(arg);
         }
 
-        inline bool has_ExamInfo_with_energy_information() const
+        void set_high_energy_threshold(float arg)
         {
-            return this->_data->get_exam_info().has_energy_information();
+            get_exam_info_sptr()->set_high_energy_thres(arg);
         }
 
-		// data import/export
+        // data import/export
 		void fill(float v) { data()->fill(v); }
 		void fill(const PETAcquisitionData& ad)
 		{
@@ -252,6 +252,14 @@ namespace sirf {
 		{
 			return 1;
 		}
+        float get_low_energy_threshold() const
+        {
+            return get_exam_info_sptr()->get_low_energy_thres();
+        }
+        float get_high_energy_threshold() const
+        {
+            return get_exam_info_sptr()->get_high_energy_thres();
+        }
 		int get_max_segment_num() const
 		{
 			return data()->get_max_segment_num();

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -193,6 +193,16 @@ namespace sirf {
 			_data = data;
 		}
 
+        inline bool has_Scanner_with_energy_information() const
+        {
+            return this->_data->get_proj_data_info_sptr()->get_scanner_sptr()->has_energy_information();
+        }
+
+        inline bool has_ExamInfo_with_energy_information() const
+        {
+            return this->_data->get_exam_info().has_energy_information();
+        }
+
 		// data import/export
 		void fill(float v) { data()->fill(v); }
 		void fill(const PETAcquisitionData& ad)

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_types.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_types.h
@@ -58,6 +58,7 @@ limitations under the License.
 #include "stir/shared_ptr.h"
 #include "stir/SSRB.h"
 #include "stir/TruncateToCylindricalFOVImageProcessor.h"
+#include "stir/scatter/SingleScatterSimulation.h"
 
 #include "stir/StirException.h"
 #include "stir/TextWriter.h"

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -399,6 +399,22 @@ The actual algorithm is described in
 		//shared_ptr<stir::BinNormalisation> sptr_normalisation_;
 	};
 
+    class PETSingleScatterSimulation : public stir::SingleScatterSimulation
+    {
+    public:
+        //!
+        PETSingleScatterSimulation() : stir::SingleScatterSimulation()
+        {
+            std::cout<< " I am Here!!! " << std::endl;
+        }
+        //!
+        PETSingleScatterSimulation(std::string filename) :
+        stir::SingleScatterSimulation(filename)
+        {}
+
+//        bool set_up();
+    };
+
 	/*!
 	\ingroup STIR Extensions
 	\brief Ray tracing matrix implementation of the PET acquisition model.

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -399,22 +399,6 @@ The actual algorithm is described in
 		//shared_ptr<stir::BinNormalisation> sptr_normalisation_;
 	};
 
-    class PETSingleScatterSimulation : public stir::SingleScatterSimulation
-    {
-    public:
-        //!
-        PETSingleScatterSimulation() : stir::SingleScatterSimulation()
-        {
-            std::cout<< " I am Here!!! " << std::endl;
-        }
-        //!
-        PETSingleScatterSimulation(std::string filename) :
-        stir::SingleScatterSimulation(filename)
-        {}
-
-//        bool set_up();
-    };
-
 	/*!
 	\ingroup STIR Extensions
 	\brief Ray tracing matrix implementation of the PET acquisition model.

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -263,54 +263,31 @@ class SingleScatterSimulator():
 
     def __del__(self):
         if self.handle is not None:
-            pyiutild.deleteDataHandle(self.handle)
+            pyiutil.deleteDataHandle(self.handle)
 
     def set_up(self):
-        print('SingleScatterSimulator:: I am in set up')
+        '''Sets up the Simulator.
+        '''
+#        AcquisitionData output_data = cSTIR.acquisition_data()
+        try_calling(pystir.cSTIR_setupSingleScatterSimulation \
+                    (self.handle, output_data.handle))
+        return output_data
 
-    def set_Acquisition_template(self, arg):
+    def set_acquisition_data(self, arg):
         ''' Set the template of the acquisition data.
         '''
-        par = pystir.cSTIR_getAcquisitionsData(arg.handle, arg.name);
-        _setParameter(self.handle, self.name, 'template_proj_data_info', par)
+        _setParameter(self.handle, self.name, 'set_acquisition_data', arg.handle)
 
-    def set_low_energy_threshold(self, threshold):
-        _set_float_par(self.handle, self.name, 'low_energy_threshold', threshold)
+    def set_activity_image(self, image):
+        _setParameter(self.handle, self.name, 'set_activity_image', image.handle)
 
-    def set_high_energy_threshold(self, threshold):
-        _set_float_par(self.handle, self.name, 'high_energy_threshold', threshold)
+    def set_attenuation_image(self, image):
+        _setParameter(self.handle, self.name, 'set_attenuation_image', image.handle)
 
-    def set_energy_resolution(self, energy_resolution):
-        ''' Set the energy properties of the Scanner in keV.
+    def simulate(self):
+        '''Performs the simulation
         '''
-        _set_float_par(self.handle, self.name, 'set_Scanner_energy_information', energy_resolution)
-
-    def has_Acquisition_template(self):
-        ''' Returns True if there is template set.
-        '''
-        return _bool_par(self.handle, self.name, 'has_template_proj_data_info')
-
-    def has_Scanner_with_Energy_info(self):
-        ''' Returns True if the Scanner tempate has information on energy (e.g. energy
-        resolution and reference energy.
-        '''
-        return _bool_par(self.handle, self.name, 'has_Scanner_with_energy_information')
-
-    def has_energy_window(self):
-        ''' Returns true if the energy window has been setup.
-        '''
-        return _bool_par(self.handle, self.name, 'has_energy_window')
-
-    def get_energy_resolution(self):
-        ''' Get the energy resolution of the Scanner.
-        '''
-        return _float_par(self.handle, self.name, 'get_energy_resolution')
-
-    def get_low_energy_threshold(self):
-        return _float_par(self.handle, self.name, 'low_energy_threshold')
-
-    def get_high_energy_threshold(self):
-        return _float_par(self.handle, self.name, 'high_energy_threshold')
+        pass
 
 
 #class ImageData(DataContainer):
@@ -797,6 +774,19 @@ class AcquisitionData(DataContainer):
         ad.fill(value)
         ad.src = 'copy'
         return ad
+
+    def set_low_energy_threshold(self, threshold):
+        _set_float_par(self.handle, self.name, 'low_energy_threshold', threshold)
+
+    def set_high_energy_threshold(self, threshold):
+        _set_float_par(self.handle, self.name, 'high_energy_threshold', threshold)
+
+    def get_low_energy_threshold(self):
+        return _float_par(self.handle, self.name, 'low_energy_threshold')
+
+    def get_high_energy_threshold(self):
+        return _float_par(self.handle, self.name, 'high_energy_threshold')
+
     def rebin(self, num_segments_to_combine, \
         num_views_to_combine = 1, num_tang_poss_to_trim = 0, \
         do_normalisation = True, max_in_segment_num_to_process = -1):

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -269,11 +269,49 @@ class SingleScatterSimulator():
         print('SingleScatterSimulator:: I am in set up')
 
     def set_Acquisition_template(self, arg):
-        pystir.cSTIR_setParameter(self.handle, self.name, 'template_proj_data_info', arg)
+        ''' Set the template of the acquisition data.
+        '''
+        par = pystir.cSTIR_getAcquisitionsData(arg.handle, arg.name);
+        _setParameter(self.handle, self.name, 'template_proj_data_info', par)
+
+    def set_low_energy_threshold(self, threshold):
+        _set_float_par(self.handle, self.name, 'low_energy_threshold', threshold)
+
+    def set_high_energy_threshold(self, threshold):
+        _set_float_par(self.handle, self.name, 'high_energy_threshold', threshold)
+
+    def set_energy_resolution(self, energy_resolution):
+        ''' Set the energy properties of the Scanner in keV.
+        '''
+        _set_float_par(self.handle, self.name, 'set_Scanner_energy_information', energy_resolution)
 
     def has_Acquisition_template(self):
-        ret = _bool_par(self.handle, self.name, 'has_template_proj_data_info')
-        return ret
+        ''' Returns True if there is template set.
+        '''
+        return _bool_par(self.handle, self.name, 'has_template_proj_data_info')
+
+    def has_Scanner_with_Energy_info(self):
+        ''' Returns True if the Scanner tempate has information on energy (e.g. energy
+        resolution and reference energy.
+        '''
+        return _bool_par(self.handle, self.name, 'has_Scanner_with_energy_information')
+
+    def has_energy_window(self):
+        ''' Returns true if the energy window has been setup.
+        '''
+        return _bool_par(self.handle, self.name, 'has_energy_window')
+
+    def get_energy_resolution(self):
+        ''' Get the energy resolution of the Scanner.
+        '''
+        return _float_par(self.handle, self.name, 'get_energy_resolution')
+
+    def get_low_energy_threshold(self):
+        return _float_par(self.handle, self.name, 'low_energy_threshold')
+
+    def get_high_energy_threshold(self):
+        return _float_par(self.handle, self.name, 'high_energy_threshold')
+
 
 #class ImageData(DataContainer):
 class ImageData(SIRF.ImageData):

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -85,6 +85,12 @@ def _char_par(handle, set, par):
     value = pyiutil.charDataFromHandle(h)
     pyiutil.deleteDataHandle(h)
     return value
+def _bool_par(handle, set, par):
+    h = pystir.cSTIR_parameter(handle, set, par)
+    check_status(h, inspect.stack()[1])
+    value = pyiutil.boolDataFromHandle(h)
+    pyiutil.deleteDataHandle(h)
+    return value
 def _int_par(handle, set, par):
     h = pystir.cSTIR_parameter(handle, set, par)
     check_status(h, inspect.stack()[1])
@@ -236,6 +242,38 @@ class EllipticCylinder(Shape):
         rx = _float_par(self.handle, self.name, 'radius_x')
         ry = _float_par(self.handle, self.name, 'radius_y')
         return (rx, ry)
+
+class SingleScatterSimulator():
+    '''
+    Class for simulating the scatter contribution in an image.
+    This class
+    '''
+    def __init__(self, filename = ''):
+        self.handle = None
+        self.image = None
+        self.name = 'SingleScatterSimulation'
+        self.filename = filename
+
+        if not self.filename:
+            self.handle = pystir.cSTIR_newObject(self.name)
+        else:
+            self.handle = pystir.cSTIR_objectFromFile
+
+        check_status(self.handle)
+
+    def __del__(self):
+        if self.handle is not None:
+            pyiutild.deleteDataHandle(self.handle)
+
+    def set_up(self):
+        print('SingleScatterSimulator:: I am in set up')
+
+    def set_Acquisition_template(self, arg):
+        pystir.cSTIR_setParameter(self.handle, self.name, 'template_proj_data_info', arg)
+
+    def has_Acquisition_template(self):
+        ret = _bool_par(self.handle, self.name, 'has_template_proj_data_info')
+        return ret
 
 #class ImageData(DataContainer):
 class ImageData(SIRF.ImageData):
@@ -1727,34 +1765,6 @@ class OSMAPOSLReconstructor(IterativeReconstructor):
 ##            (self.handle, self.name, 'objective_function')
 ##        check_status(obj_fun.handle)
 ##        return obj_fun
-
-class SingleScatterSimulator():
-    '''
-    Class for simulating the scatter contribution in an image.
-    This class
-    '''
-    def __init__(self, filename = ''):
-        self.handle = None
-        self.image = None
-        self.name = 'PETSingleScatterSimulation'
-        self.filename = filename
-
-        if not self.filename:
-            self.handle = pystir.cSTIR_newObject(self.name)
-            print('SingleScatterSimulator:: I am in Constructor 0000')
-        else:
-            self.handle = pystir.cSTIR_objectFromFile
-            ('PETSingleScatterSimulation', self.filename)
-
-        print('SingleScatterSimulator:: I am in Constructor')
-        check_status(self.handle)
-
-    def __del__(self):
-        if self.handle is not None:
-            pyiutild.deleteDataHandle(self.handle)
-
-    def set_up(self):
-        print('SingleScatterSimulator:: I am in set up')
 
 class OSSPSReconstructor(IterativeReconstructor):
     '''

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -1728,6 +1728,34 @@ class OSMAPOSLReconstructor(IterativeReconstructor):
 ##        check_status(obj_fun.handle)
 ##        return obj_fun
 
+class SingleScatterSimulator():
+    '''
+    Class for simulating the scatter contribution in an image.
+    This class
+    '''
+    def __init__(self, filename = ''):
+        self.handle = None
+        self.image = None
+        self.name = 'PETSingleScatterSimulation'
+        self.filename = filename
+
+        if not self.filename:
+            self.handle = pystir.cSTIR_newObject(self.name)
+            print('SingleScatterSimulator:: I am in Constructor 0000')
+        else:
+            self.handle = pystir.cSTIR_objectFromFile
+            ('PETSingleScatterSimulation', self.filename)
+
+        print('SingleScatterSimulator:: I am in Constructor')
+        check_status(self.handle)
+
+    def __del__(self):
+        if self.handle is not None:
+            pyiutild.deleteDataHandle(self.handle)
+
+    def set_up(self):
+        print('SingleScatterSimulator:: I am in set up')
+
 class OSSPSReconstructor(IterativeReconstructor):
     '''
     Class for reconstructor objects using Ordered Subsets Separable 


### PR DESCRIPTION
Work in progress. 
In order to be able to run this branch you have to switch to the Scatter_simulation branch in STIR (recompile and install). 
You can get this branch from [here](https://github.com/NikEfth/STIR/tree/Scatter_simulation).

Progress: 
- [x] We can create a Single Scatter simulation object from SIRF
- [x] Set the template projdata info in SSS and check
- [ ] Run ```SingleScatterSimulator::set_up()```
- [ ] Run ```SingleScatterSimulator::simulate()```