### PR TITLE
Add MR cpp tests

### DIFF
--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(cgadgetron PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_
 
 target_include_directories(cgadgetron PUBLIC "${cGadgetron_INCLUDE_DIR}")
 target_include_directories(cgadgetron PRIVATE "${FFTW3_INCLUDE_DIR}")
-target_include_directories(cgadgetron PRIVATE "${ISMRMRD_INCLUDE_DIR}")
+target_include_directories(cgadgetron PUBLIC "${ISMRMRD_INCLUDE_DIR}")
 
 target_link_libraries(cgadgetron iutilities csirf)
 # Add boost library dependencies
@@ -70,3 +70,5 @@ endif()
 target_link_libraries(cgadgetron ${ismrmrd_full_path})
 target_link_libraries(cgadgetron "${FFTW3_LIBRARIES}")
 target_link_libraries(cgadgetron "${HDF5_LIBRARIES}")
+
+ADD_SUBDIRECTORY(tests)

--- a/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+#========================================================================
+# Author: Johannes Mayer
+# Copyright 2016 University College London
+# Copyright 2020 Physikalisch Technische Bundesantalt
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+add_executable(MR_TEST_CPLUSPLUS ${CMAKE_CURRENT_SOURCE_DIR}/mrtests.cpp)
+target_link_libraries(MR_TEST_CPLUSPLUS PUBLIC csirf cgadgetron)
+INSTALL(TARGETS MR_TEST_CPLUSPLUS DESTINATION bin)
+
+ADD_TEST(NAME MR_TEST_CPLUSPLUS
+         COMMAND MR_TEST_CPLUSPLUS
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #========================================================================
 # Author: Johannes Mayer
 # Copyright 2016 University College London
-# Copyright 2020 Physikalisch Technische Bundesantalt
+# Copyright 2020 Physikalisch-Technische Bundesanstalt Berlin
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/xGadgetron/cGadgetron/tests/mrtests.cpp
+++ b/src/xGadgetron/cGadgetron/tests/mrtests.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <cstdlib>
+
+//#include "sirf/common/DataContainer.h"
+#include "sirf/Gadgetron/gadgetron_data_containers.h"
+
+using namespace sirf;
+
+int main ()
+{
+	try{
+        std::cout << "Hello Tests." << std::endl;
+        return 0;
+	}
+	catch(...)
+	{
+
+	}
+}


### PR DESCRIPTION
I set up a test environment for the xGadgetron code on the cpp level, so I can write tests for the inclusion of trajectory and encoding models.

I just went along analogously to the other CMake directories who had tests in them.

If the copyright tag is wrong please let me know.