### PR TITLE
Proper in-place algebra

### DIFF
--- a/examples/Python/MR/acquisition_model.py
+++ b/examples/Python/MR/acquisition_model.py
@@ -133,13 +133,6 @@ def main():
           % simulated_acq_data.norm())
     if output_file is not None:
         simulated_acq_data.write(output_file)
-    # testing in-place algebra
-    acq = simulated_acq_data
-    acq_clone = acq.clone()
-    acq_clone /= acq_clone
-    acq_clone *= acq
-    acq_clone -= acq
-    print('%f is 0.0' % (acq_clone.norm()/acq.norm()))
 
     # display simulated acquisition data
     #simulated_acq_data.show(title = 'Simulated acquisition data (magnitude)')
@@ -156,20 +149,6 @@ def main():
 
     diff = backprojected_data/b_norm - reconstructed_images/r_norm
     print('norm of backprojected - reconstructed images: %f' % diff.norm())
-    # testing fill
-    reconstructed_images.fill(backprojected_data)
-    # testing +=
-    backprojected_data += reconstructed_images*(-1)
-    print('%f is 0.0' % (backprojected_data.norm()))
-    #diff = (backprojected_data - reconstructed_images).norm()
-    #if diff > 0:
-    #    print('fill error: %f' % diff)
-    images_copy = reconstructed_images.copy()
-    # testing /=, *= and -=
-    images_copy /= images_copy
-    images_copy *= reconstructed_images
-    images_copy -= reconstructed_images
-    print('%f is 0.0' % (images_copy.norm()))
 
 try:
     main()

--- a/examples/Python/MR/acquisition_model.py
+++ b/examples/Python/MR/acquisition_model.py
@@ -133,6 +133,10 @@ def main():
           % simulated_acq_data.norm())
     if output_file is not None:
         simulated_acq_data.write(output_file)
+    acq = simulated_acq_data
+    acq_clone = acq.clone()
+    acq_clone += acq*(-1)
+    print(acq_clone.norm()/acq.norm())
 
     # display simulated acquisition data
     #simulated_acq_data.show(title = 'Simulated acquisition data (magnitude)')
@@ -151,9 +155,11 @@ def main():
     print('norm of backprojected - reconstructed images: %f' % diff.norm())
     # testing fill
     reconstructed_images.fill(backprojected_data)
-    diff = (backprojected_data - reconstructed_images).norm()
-    if diff > 0:
-        print('fill error: %f' % diff)
+    backprojected_data += reconstructed_images*(-1)
+    print(backprojected_data.norm())
+    #diff = (backprojected_data - reconstructed_images).norm()
+    #if diff > 0:
+    #    print('fill error: %f' % diff)
 
 try:
     main()

--- a/examples/Python/MR/acquisition_model.py
+++ b/examples/Python/MR/acquisition_model.py
@@ -133,10 +133,13 @@ def main():
           % simulated_acq_data.norm())
     if output_file is not None:
         simulated_acq_data.write(output_file)
+    # testing in-place algebra
     acq = simulated_acq_data
     acq_clone = acq.clone()
-    acq_clone += acq*(-1)
-    print(acq_clone.norm()/acq.norm())
+    acq_clone /= acq_clone
+    acq_clone *= acq
+    acq_clone -= acq
+    print('%f is 0.0' % (acq_clone.norm()/acq.norm()))
 
     # display simulated acquisition data
     #simulated_acq_data.show(title = 'Simulated acquisition data (magnitude)')
@@ -155,11 +158,18 @@ def main():
     print('norm of backprojected - reconstructed images: %f' % diff.norm())
     # testing fill
     reconstructed_images.fill(backprojected_data)
+    # testing +=
     backprojected_data += reconstructed_images*(-1)
-    print(backprojected_data.norm())
+    print('%f is 0.0' % (backprojected_data.norm()))
     #diff = (backprojected_data - reconstructed_images).norm()
     #if diff > 0:
     #    print('fill error: %f' % diff)
+    images_copy = reconstructed_images.copy()
+    # testing /=, *= and -=
+    images_copy /= images_copy
+    images_copy *= reconstructed_images
+    images_copy -= reconstructed_images
+    print('%f is 0.0' % (images_copy.norm()))
 
 try:
     main()

--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -106,7 +106,10 @@ def main():
     acq_factor = acq_data.get_uniform_copy(0.1)
     new_acq_data = acq_data / acq_factor
     print('norm of acq_data*10: %f' % new_acq_data.norm())
-    acq_copy = acq_data.get_uniform_copy()
+    acq_copy = acq_data.get_uniform_copy(1.0)
+    acq_copy *= acq_data
+    diff = acq_copy - acq_data
+    print('norm of acq_copy - acq_data: %f' % diff.norm())
     acq_copy.fill(acq_data)
     diff = acq_copy - acq_data
     print('norm of acq_copy - acq_data: %f' % diff.norm())
@@ -130,6 +133,9 @@ def main():
     diff -= image
     print('norm of image.clone() - image: %f' % diff.norm())
     image_copy = image.get_uniform_copy()
+    image_copy *= image
+    diff = image_copy - image
+    print('norm of image_copy - image: %f' % diff.norm())
     image_copy.fill(image)
     diff = image_copy - image
     print('norm of image_copy - image: %f' % diff.norm())

--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -100,8 +100,7 @@ def main():
     print('norm of acq_data.as_array(): %f' % numpy.linalg.norm(acq_array))
     print('acq_data.norm(): %f' % s)
     print('sqrt(acq_data.dot(acq_data)): %f' % math.sqrt(t))
-    diff = new_acq_data
-    diff -= acq_data
+    diff = new_acq_data - acq_data
     print('norm of acq_data.clone() - acq_data: %f' % diff.norm())
     acq_factor = acq_data.get_uniform_copy(0.1)
     new_acq_data = acq_data / acq_factor
@@ -129,8 +128,7 @@ def main():
     image_factor = image.get_uniform_copy(0.1)
     image = image / image_factor
     print('norm of image*10: %f' % image.norm())
-    diff = image.clone()
-    diff -= image
+    diff = image.clone() - image
     print('norm of image.clone() - image: %f' % diff.norm())
     image_copy = image.get_uniform_copy()
     image_copy *= image

--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -100,7 +100,8 @@ def main():
     print('norm of acq_data.as_array(): %f' % numpy.linalg.norm(acq_array))
     print('acq_data.norm(): %f' % s)
     print('sqrt(acq_data.dot(acq_data)): %f' % math.sqrt(t))
-    diff = new_acq_data - acq_data
+    diff = new_acq_data
+    diff -= acq_data
     print('norm of acq_data.clone() - acq_data: %f' % diff.norm())
     acq_factor = acq_data.get_uniform_copy(0.1)
     new_acq_data = acq_data / acq_factor
@@ -125,7 +126,8 @@ def main():
     image_factor = image.get_uniform_copy(0.1)
     image = image / image_factor
     print('norm of image*10: %f' % image.norm())
-    diff = image.clone() - image
+    diff = image.clone()
+    diff -= image
     print('norm of image.clone() - image: %f' % diff.norm())
     image_copy = image.get_uniform_copy()
     image_copy.fill(image)

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -403,7 +403,8 @@ class DataContainer(ABC):
             z = other * self
             self.fill(z.as_array())
             return self
-        self.fill(self.multiply(other).as_array())
+        #self.fill(self.multiply(other).as_array())
+        self.multiply(other, out=self)
         return self
     def __isub__(self, other):
         '''Not quite in-place subtract'''
@@ -416,7 +417,8 @@ class DataContainer(ABC):
             z = (1./other) * self
             self.fill(z.as_array())
             return self
-        self.fill(self.divide(other).as_array())
+        #self.fill(self.divide(other).as_array())
+        self.divide(other, out=self)
         return self
     def abs(self, out=None):
         '''Returns the element-wise absolute value of the DataContainer data

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -394,7 +394,8 @@ class DataContainer(ABC):
     # inline algebra
     def __iadd__(self, other):
         '''Not quite in-place add'''
-        self.fill(self.add(other))
+        #self.fill(self.add(other))
+        self.subtract(other, out=self)
         return self
     def __imul__(self, other):
         '''Not quite in-place multiplication'''
@@ -406,7 +407,8 @@ class DataContainer(ABC):
         return self
     def __isub__(self, other):
         '''Not quite in-place subtract'''
-        self.fill(self.subtract(other).as_array())
+        #self.fill(self.subtract(other).as_array())
+        self.subtract(other, out=self)
         return self
     def __idiv__(self, other):
         '''Not quite in-place division'''

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -395,7 +395,7 @@ class DataContainer(ABC):
     def __iadd__(self, other):
         '''Not quite in-place add'''
         #self.fill(self.add(other))
-        self.subtract(other, out=self)
+        self.add(other, out=self)
         return self
     def __imul__(self, other):
         '''Not quite in-place multiplication'''

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -378,11 +378,13 @@ complex_float_t a, complex_float_t b)
 	int n = y.number();
 	ISMRMRD::Acquisition ax;
 	ISMRMRD::Acquisition ay;
+	ISMRMRD::Acquisition acq;
 	bool isempty = (number() < 1);
 	try {
 		for (int i = 0, j = 0, k = 0; i < n && j < m;) {
 			y.get_acquisition(i, ay);
 			x.get_acquisition(j, ax);
+			get_acquisition(k, acq);
 			if (TO_BE_IGNORED(ay)) {
 				std::cout << i << " ignored (ay)\n";
 				i++;
@@ -391,6 +393,11 @@ complex_float_t a, complex_float_t b)
 			if (TO_BE_IGNORED(ax)) {
 				std::cout << j << " ignored (ax)\n";
 				j++;
+				continue;
+			}
+			if (TO_BE_IGNORED(acq)) {
+				std::cout << k << " ignored (acq)\n";
+				k++;
 				continue;
 			}
 			switch (op) {
@@ -416,7 +423,8 @@ complex_float_t a, complex_float_t b)
 		}
 	}
 	catch (...) {
-		empty();
+		AcquisitionsFile ac(acqs_info_);
+//		empty();
 		for (int i = 0, j = 0; i < n && j < m;) {
 			y.get_acquisition(i, ay);
 			x.get_acquisition(j, ax);
@@ -443,10 +451,12 @@ complex_float_t a, complex_float_t b)
 			default:
 				THROW("wrong operation in MRAcquisitionData::binary_op_");
 			}
-			append_acquisition(ay);
+//			append_acquisition(ay);
+			ac.append_acquisition(ay);
 			i++;
 			j++;
 		}
+		take_over(ac);
 	}
 }
 
@@ -751,7 +761,7 @@ AcquisitionsFile::empty()
 }
 
 void 
-AcquisitionsFile::take_over(AcquisitionsFile& af)
+AcquisitionsFile::take_over_impl(AcquisitionsFile& af)
 {
 	acqs_info_ = af.acquisitions_info();
 	sorted_ = af.sorted();

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -222,6 +222,7 @@ namespace sirf {
 		// abstract methods
 
 		virtual void empty() = 0;
+		virtual void take_over(MRAcquisitionData&) = 0;
 
 		// the number of acquisitions in the container
 		virtual unsigned int number() const = 0;
@@ -361,13 +362,18 @@ namespace sirf {
 
 		// implements 'overwriting' of an acquisition file data with new values:
 		// in reality, creates new file with new data and deletes the old one
-		void take_over(AcquisitionsFile& ac);
+		void take_over_impl(AcquisitionsFile& ac);
 
 		void write_acquisitions_info();
 
 		// implementations of abstract methods
 
 		virtual void empty();
+		virtual void take_over(MRAcquisitionData& ad)
+		{
+			AcquisitionsFile& af = dynamic_cast<AcquisitionsFile&>(ad);
+			take_over_impl(af);
+		}
 		virtual void set_data(const complex_float_t* z, int all = 1);
 		virtual unsigned int items() const;
 		virtual unsigned int number() const { return items(); }
@@ -436,6 +442,7 @@ namespace sirf {
 			_storage_scheme = "memory";
 		}
 		virtual void empty();
+		virtual void take_over(MRAcquisitionData& ad) {}
 		virtual unsigned int number() const { return (unsigned int)acqs_.size(); }
 		virtual unsigned int items() const { return (unsigned int)acqs_.size(); }
 		virtual void append_acquisition(ISMRMRD::Acquisition& acq)

--- a/src/xGadgetron/pGadgetron/tests/test1.py
+++ b/src/xGadgetron/pGadgetron/tests/test1.py
@@ -106,6 +106,19 @@ def test_main(rec=False, verb=False, throw=True):
     d = numpy.linalg.norm(pad2_arr - pad_arr/2)
     print('acquisitions division (with out=) error: %.1e' % d)
     test.check_if_equal(0, d)
+    # testing in-place algebra
+    acq = processed_data
+    acq_clone = acq.clone()
+    acq_clone /= acq_clone
+    acq_clone *= acq
+    acq_clone -= acq
+    d = acq_clone.norm()/acq.norm()
+    print('%f is 0.0' % d)
+    test.check_if_equal(1, d < 1e-6)
+    acq_clone += acq
+    d = (acq_clone.norm() - acq.norm())/acq.norm()
+    print('%f is 0.0' % d)
+    test.check_if_equal(1, d < 1e-6)
 
     ci2 = complex_images - complex_images
     ci2_arr = ci2.as_array()
@@ -141,6 +154,18 @@ def test_main(rec=False, verb=False, throw=True):
     d = numpy.linalg.norm(ci2_arr - ci_arr/2)
     print('images division (with out=) error: %.1e' % d)
     test.check_if_equal(0, d)
+    images_copy = complex_images.copy()
+    # testing /=, *= and -=
+    images_copy /= images_copy
+    images_copy *= complex_images
+    images_copy -= complex_images
+    d = images_copy.norm()/complex_images.norm()
+    print('%f is 0.0' % d)
+    test.check_if_equal(1, d < 1e-6)
+    images_copy += complex_images
+    d = (images_copy.norm() - complex_images.norm())/complex_images.norm()
+    print('%f is 0.0' % d)
+    test.check_if_equal(1, d < 1e-6)
 
     return test.failed, test.ntest
 

--- a/src/xSTIR/pSTIR/STIR.py.in
+++ b/src/xSTIR/pSTIR/STIR.py.in
@@ -2142,12 +2142,16 @@ class OSSPSReconstructor(IterativeReconstructor):
         parms.set_float_par\
             (self.handle, self.name, 'relaxation_parameter', value)
 
-def make_Poisson_loglikelihood(acq_data, model = 'LinearModelForMean'):
+def make_Poisson_loglikelihood(acq_data, likelihood_model='LinearModelForMean'):
     '''
-    Selects the objective function based on the acquisition data and acquisition
+    Selects the objective function based on the acquisition data and likelihood
     model types.
     '''
     # only this objective function is implemented for now
-    obj_fun = PoissonLogLikelihoodWithLinearModelForMeanAndProjData()
-    obj_fun.set_acquisition_data(acq_data)
+    if likelihood_model == 'LinearModelForMean':
+        obj_fun = PoissonLogLikelihoodWithLinearModelForMeanAndProjData()
+        obj_fun.set_acquisition_data(acq_data)
+    else:
+        raise error('only PoissonLogLikelihoodWithLinearModelForMeanAndProjData '
+                  + 'is currently implemented in SIRF')
     return obj_fun

--- a/src/xSTIR/pSTIR/tests/tests_listmode.py
+++ b/src/xSTIR/pSTIR/tests/tests_listmode.py
@@ -36,6 +36,8 @@ def test_main(rec=False, verb=False, throw=True):
     if abs(time_at_which_prompt_rate_exceeds_threshold-known_time) > 1.e-4:
         raise AssertionError("ListmodeToSinograms::get_time_at_which_prompt_rate_exceeds_threshold failed")
 
+    return 0, 1
+
 
 if __name__ == "__main__":
     runner(test_main, __doc__, __version__, __author__)

--- a/src/xSTIR/pSTIR/tests/tests_niftypet.py
+++ b/src/xSTIR/pSTIR/tests/tests_niftypet.py
@@ -72,7 +72,10 @@ def test_main(rec=False, verb=False, throw=True):
     image = get_image()
 
     # Get AM
-    acq_model = AcquisitionModelUsingNiftyPET()
+    try:
+        acq_model = AcquisitionModelUsingNiftyPET()
+    except:
+        return 1, 1
     acq_model.set_cuda_verbosity(verb)
     acq_model.set_up(template_acq_data, image)
 
@@ -100,6 +103,8 @@ def test_main(rec=False, verb=False, throw=True):
     reconstructed_im = recon.get_output()
     if not reconstructed_im:
         raise AssertionError()
+
+    return 0, 1
 
 if __name__ == "__main__":
     runner(test_main, __doc__, __version__, __author__)

--- a/src/xSTIR/pSTIR/tests/tests_two.py
+++ b/src/xSTIR/pSTIR/tests/tests_two.py
@@ -65,44 +65,56 @@ def test_main(rec=False, verb=False, throw=True):
         print('relative residual norm: %e' % (diff.norm() / acq_data.norm()))
     test.check(diff.norm())
 
-    acq_copy = acq_data.get_uniform_copy()
-    acq_copy.fill(acq_data)
-    pad2 = acq_data - acq_data
-    pad2_arr = pad2.as_array()
-    d = numpy.linalg.norm(pad2_arr)
+    acq_copy = acq_data.get_uniform_copy(1.0)
+    acq_copy *= acq_data
+    diff = acq_copy
+    diff -= acq_data
+    d = diff.norm()
+    print('in-place algebra error: %.1e' % d)
+    test.check_if_equal(0, d)
+    acq_copy += acq_data
+    diff = acq_data - acq_copy
+    diff_arr = diff.as_array()
+    d = numpy.linalg.norm(diff_arr)
     print('acquisitions subtraction error: %.1e' % d)
     test.check_if_equal(0, d)
-    acq_data.subtract(acq_data, out=pad2)
-    pad2_arr = pad2.as_array()
-    d = numpy.linalg.norm(pad2_arr)
+    acq_data.subtract(acq_data, out=diff)
+    diff_arr = diff.as_array()
+    d = numpy.linalg.norm(diff_arr)
     print('acquisitions subtraction (with out=) error: %.1e' % d)
     test.check_if_equal(0, d)
-    pad2 = acq_data * acq_data
-    pad_arr = acq_data.as_array()
-    pad2_arr = pad2.as_array()
-    d = numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    ad2 = acq_data * acq_data
+    ad_arr = acq_data.as_array()
+    ad2_arr = ad2.as_array()
+    d = numpy.linalg.norm(ad2_arr - ad_arr*ad_arr)
     print('acquisitions multiplication error: %.1e' % d)
     test.check_if_equal(0, d)
-    acq_data.multiply(acq_data, out=pad2)
-    pad2_arr = pad2.as_array()
-    d = numpy.linalg.norm(pad2_arr - pad_arr*pad_arr)
+    acq_data.multiply(acq_data, out=ad2)
+    ad2_arr = ad2.as_array()
+    d = numpy.linalg.norm(ad2_arr - ad_arr*ad_arr)
     print('acquisitions multiplication (with out=) error: %.1e' % d)
     test.check_if_equal(0, d)
-    pad2_arr[:] = 2.0
-    acq_copy.fill(pad2_arr)
-    pad2 = acq_data / acq_copy
-    pad2_arr = pad2.as_array()
-    d = numpy.linalg.norm(pad2_arr - pad_arr/2)
+    ad2_arr[:] = 2.0
+    acq_copy.fill(ad2_arr)
+    ad2 = acq_data / acq_copy
+    ad2_arr = ad2.as_array()
+    d = numpy.linalg.norm(ad2_arr - ad_arr/2)
     print('acquisitions division error: %.1e' % d)
     test.check_if_equal(0, d)
-    acq_data.divide(acq_copy, out=pad2)
-    pad2_arr = pad2.as_array()
-    d = numpy.linalg.norm(pad2_arr - pad_arr/2)
+    acq_data.divide(acq_copy, out=ad2)
+    ad2_arr = ad2.as_array()
+    d = numpy.linalg.norm(ad2_arr - ad_arr/2)
     print('acquisitions division (with out=) error: %.1e' % d)
     test.check_if_equal(0, d)
 
-    image_copy = image.get_uniform_copy()
-    image_copy.fill(image)
+    image_copy = image.get_uniform_copy(1.0)
+    image_copy *= image
+    diff = image_copy
+    diff -= image
+    d = diff.norm()
+    print('in-place algebra error: %.1e' % d)
+    test.check_if_equal(0, d)
+    image_copy += image
     im2 = image - image_copy
     im2_arr = im2.as_array()
     d = numpy.linalg.norm(im2_arr)


### PR DESCRIPTION
In-place data containers algebra (`+=`, `-=`, `*=` and `/=`) was temporarily implemented in SIRF via numpy in-place algebra and `as_array`/`fill`.

This PR replaces the temproary implementation with a proper one that eliminates unnecessary copying of data between SIRF data containers and numpy arrays.