### PR TITLE
Change default verbose value for adjoint tester

### DIFF
--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -466,7 +466,7 @@ def str_to_int_list(str_list):
         int_list = int_list + int_item
     return int_list
 
-def is_operator_adjoint(operator, num_tests = 5, max_err = 10e-5, verbose = False):
+def is_operator_adjoint(operator, num_tests = 5, max_err = 10e-5, verbose = True):
     '''
     Test if a given operator is adjoint.
     The operator needs to have been already set_up() with valid objects.


### PR DESCRIPTION
Related to #637


This branch attempts to fix that issue, yet we don't know what is needed yet. 
In my PC, 300 tests on gadgetron always pass the adjoint test.