### PR TITLE
Option to use symmetric f3d. default to off

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 * Ability to pad `NiftiImageData`, e.g., `a.pad([10,10,0],[10,10,0])` to add 10 voxels to the minimum and maximum of the x- and y-directions.
 * Ability to set and get STIR verbosity from python.
 * Save STIR images using a parameter file (e.g., for saving as `.nii`)
+* Default F3d to using non-symmetric version (previously, symmetric was used). Option to use the symmetric in C++, but currently exposed to python and matlab as we suspect there is an upstream bug there.
 
 ## v2.1.0
 

--- a/src/Registration/cReg/CMakeLists.txt
+++ b/src/Registration/cReg/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True)
 # Configure the aladin/f3d files dependent on NIFTYREG version number
 include(${CMAKE_CURRENT_SOURCE_DIR}/../callable_NR_methods.cmake)
 get_parser_methods("../callable_NR_aladin_methods.txt" "reg_aladin_sym" "${NIFTYREG_VERSION}" NR_aladin_parser_methods)
-get_parser_methods("../callable_NR_f3d_methods.txt"    "reg_f3d_sym"    "${NIFTYREG_VERSION}" NR_f3d_parser_methods   )
+get_parser_methods("../callable_NR_f3d_methods.txt"    "reg_f3d"    "${NIFTYREG_VERSION}" NR_f3d_parser_methods   )
 get_runtime_methods("../callable_NR_aladin_methods.txt" "${NIFTYREG_VERSION}" NR_aladin_runtime_methods)
 get_runtime_methods("../callable_NR_f3d_methods.txt"    "${NIFTYREG_VERSION}" NR_f3d_runtime_methods   )
 get_list_of_wrapped_methods("../callable_NR_aladin_methods.txt" "${NIFTYREG_VERSION}" NR_aladin_list_methods)

--- a/src/Registration/cReg/NiftyF3dSym.cpp.in
+++ b/src/Registration/cReg/NiftyF3dSym.cpp.in
@@ -50,7 +50,12 @@ void NiftyF3dSym<dataType>::process()
     NiftiImageData3D<dataType> flo = *this->_floating_images_nifti.at(0);
 
     // Create the registration object
-    _registration_sptr = std::shared_ptr<reg_f3d_sym<dataType> >(new reg_f3d_sym<dataType>(_reference_time_point, _floating_time_point));
+    if (_use_symmetric)
+        _registration_sptr = std::make_shared<reg_f3d_sym<dataType> >(_reference_time_point, _floating_time_point);
+    else
+        _registration_sptr = std::make_shared<reg_f3d<dataType> >(_reference_time_point, _floating_time_point);
+
+    // Set reference and floating images
     _registration_sptr->SetReferenceImage(ref.get_raw_nifti_sptr().get());
     _registration_sptr->SetFloatingImage(flo.get_raw_nifti_sptr().get());
 
@@ -153,7 +158,7 @@ void NiftyF3dSym<dataType>::parse_parameter_file()
     if (this->_parameter_filename.empty())
         return;
 
-    Parser<reg_f3d_sym<dataType> > parser;
+    Parser<reg_f3d<dataType> > parser;
     parser.set_object   (    _registration_sptr     );
     parser.set_filename ( this->_parameter_filename );
 

--- a/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
@@ -23,6 +23,10 @@ limitations under the License.
 \ingroup Registration
 \brief NiftyReg's f3d class for non-rigid registrations.
 
+The user has the choice to use the symmetric or non-symmetric version of the algorithm. 
+We believe there to be an upstream bug (https://github.com/KCL-BMEIS/niftyreg/issues/71)
+in the symmetric version, and therefore do not recommend using it until that issue is closed.
+
 \author Richard Brown
 \author CCP PETMR
 */

--- a/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
@@ -31,7 +31,7 @@ limitations under the License.
 
 #include "sirf/Reg/NiftyRegistration.h"
 
-template<class dataType> class reg_f3d_sym;
+template<class dataType> class reg_f3d;
 
 namespace sirf {
 
@@ -70,6 +70,10 @@ public:
     /// Set reference time point
     void set_reference_time_point(const int reference_time_point) { _reference_time_point = reference_time_point; }
 
+    /// Set use symmetric. Default is false. 
+    /// No need to expose to python/matlab until https://github.com/KCL-BMEIS/niftyreg/issues/71 is closed.
+    void set_use_symmetric(const bool use_symmetric) { _use_symmetric = use_symmetric; }
+
     /// Set initial affine transformation
     void set_initial_affine_transformation(const std::shared_ptr<const AffineTransformation<float> > mat) { _initial_transformation_sptr = mat; }
 
@@ -88,12 +92,14 @@ protected:
     void set_parameters();
 
     /// Registration object
-    std::shared_ptr<reg_f3d_sym<dataType> > _registration_sptr;
+    std::shared_ptr<reg_f3d<dataType> > _registration_sptr;
 
     /// Floating time point
     int _floating_time_point;
     /// Reference time point
     int _reference_time_point;
+    /// Use symmetric bool
+    bool _use_symmetric = false;
     /// Transformation matrix
     std::shared_ptr<const AffineTransformation<float> > _initial_transformation_sptr;
 };

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -813,18 +813,29 @@ int main(int argc, char* argv[])
         std::cout << "//                  Starting Nifty f3d test..\n";
         std::cout << "//------------------------------------------------------------------------ //\n";
 
+
+        // Crop input to increase speed
+        const int *dim = ref_f3d->get_dimensions();
+        int mid[3] = { int(dim[1]/2), int(dim[2]/2), int(dim[3]/2) };
+        int min_idx[7] = { mid[0]-5,mid[1]-5,mid[2]-5,0,0,0,0};
+        int max_idx[7] = { mid[0]+5,mid[1]+4,mid[2]+3,0,0,0,0};
+        std::shared_ptr<NiftiImageData3D<float> > ref_f3d_crop = ref_f3d->clone();
+        ref_f3d_crop->crop(min_idx, max_idx);
+        std::shared_ptr<NiftiImageData3D<float> > flo_f3d_crop = flo_f3d->clone();
+        flo_f3d_crop->crop(min_idx, max_idx);
+
         // Print all available methods
         NiftyF3dSym<float>::print_all_wrapped_methods();
 
         // First set up some masks
-        std::shared_ptr<NiftiImageData3D<float> > ref_mask = ref_f3d->clone();
-        std::shared_ptr<NiftiImageData3D<float> > flo_mask = flo_f3d->clone();
+        std::shared_ptr<NiftiImageData3D<float> > ref_mask = ref_f3d_crop->clone();
+        std::shared_ptr<NiftiImageData3D<float> > flo_mask = flo_f3d_crop->clone();
         ref_mask->fill(1.F);
         flo_mask->fill(1.F);
 
         NiftyF3dSym<float> NF;
-        NF.set_reference_image               (           ref_f3d          );
-        NF.set_floating_image                (           flo_f3d          );
+        NF.set_reference_image               (        ref_f3d_crop        );
+        NF.set_floating_image                (        flo_f3d_crop        );
         NF.set_parameter_file                (     parameter_file_f3d     );
         NF.set_reference_time_point          (             1              );
         NF.set_floating_time_point           (             1              );
@@ -845,6 +856,18 @@ int main(int argc, char* argv[])
         disp_forward_sptr->write(f3d_disp_forward);
         disp_inverse_sptr->write_split_xyz_components(f3d_disp_inverse);
 
+        // Check that if ref==flo, out is very similar
+        NiftyF3dSym<float> NF2;
+        NF2.set_reference_image               (    ref_f3d_crop    );
+        NF2.set_floating_image                (    ref_f3d_crop    );
+        NF2.set_parameter_file                ( parameter_file_f3d );
+        NF2.set_reference_time_point          (          1         );
+        NF2.set_floating_time_point           (          1         );
+        NF2.set_reference_mask(ref_mask);
+        NF2.set_floating_mask(flo_mask);
+        NF2.process();
+        if (*NF2.get_output_sptr() != *ref_f3d_crop)
+            throw std::runtime_error("NiftyF3dSym failed: ref==flo, but registered image != ref");
 
         std::cout << "// ----------------------------------------------------------------------- //\n";
         std::cout << "//                  Finished Nifty f3d test.\n";


### PR DESCRIPTION
Fixes https://github.com/SyneRBI/SIRF/issues/680.

Added a test that says "if ref==flo, I expect registered image to ~= ref". This test fails with old (symmetric) implementation, but passes for the new fix.