### PR TITLE
ProjDataInMemory changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## vX.X.X
+
+* if `storage_scheme` is set to `memory`, then `PETAcquisitionData` will now contain `ProjDataInMemory`, instead of `ProjDataFromStream`. As such, if storage scheme is set to memory, it will now be possible to open a PET acquisition data and modify it directly, whereas before a copy would need to be created first.
+
 ## v2.2.0-rc.1
 
 * A passthrough for both the maximum and minimum relative change during OSMAPOSL reconstruction has been added.

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -239,9 +239,12 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 			return newObjectHandle(sptr);
 		}
 		if (boost::iequals(name, "AcquisitionData")) {
-            shared_ptr<PETAcquisitionData> sptr(new PETAcquisitionDataInFile(filename));
-            if (PETAcquisitionData::storage_scheme().compare("memory") == 0)
-                sptr.reset(new PETAcquisitionDataInMemory(*sptr));
+
+            shared_ptr<PETAcquisitionData> sptr;
+            if (PETAcquisitionData::storage_scheme().compare("file") == 0)
+                sptr.reset(new PETAcquisitionDataInFile(filename));
+            else
+                sptr.reset(new PETAcquisitionDataInMemory(filename));
 			return newObjectHandle(sptr);
 		}
 		if (boost::iequals(name, "ListmodeToSinograms")) {

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -239,8 +239,9 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 			return newObjectHandle(sptr);
 		}
 		if (boost::iequals(name, "AcquisitionData")) {
-			shared_ptr<PETAcquisitionData> 
-				sptr(new PETAcquisitionDataInFile(filename));
+            shared_ptr<PETAcquisitionData> sptr(new PETAcquisitionDataInFile(filename));
+            if (PETAcquisitionData::storage_scheme().compare("memory") == 0)
+                sptr.reset(new PETAcquisitionDataInMemory(*sptr));
 			return newObjectHandle(sptr);
 		}
 		if (boost::iequals(name, "ListmodeToSinograms")) {

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -438,9 +438,11 @@ namespace sirf {
 			ptr->fill(0.0f);
 			_data.reset(ptr);
 		}
-        PETAcquisitionDataInMemory(const char* filename)
+        /// Constructor that reads as PETAcquisitionDataInFile then converts to PETAcquisitionDataInMemory
+        PETAcquisitionDataInMemory(const char* filename) :
+            PETAcquisitionDataInMemory(PETAcquisitionDataInFile(filename))
         {
-            PETAcquisitionDataInMemory(PETAcquisitionDataInFile(filename));
+
         }
 
 		static void init() 

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -438,6 +438,10 @@ namespace sirf {
 			ptr->fill(0.0f);
 			_data.reset(ptr);
 		}
+        PETAcquisitionDataInMemory(const char* filename)
+        {
+            PETAcquisitionDataInMemory(PETAcquisitionDataInFile(filename));
+        }
 
 		static void init() 
 		{ 

--- a/src/xSTIR/pSTIR/STIR.py.in
+++ b/src/xSTIR/pSTIR/STIR.py.in
@@ -614,7 +614,7 @@ class AcquisitionData(DataContainer):
                 # src is a file name
                 self.handle = pystir.cSTIR_objectFromFile\
                             ('AcquisitionData', src)
-                self.read_only = True
+                self.read_only = self.get_storage_scheme() == 'file'
                 self.src = 'file'
             else:
                 # src is a scanner name


### PR DESCRIPTION
It seems that if `storage_scheme` is set to `memory`, sinograms are still read as `ProjDataFromStream`. Here, we convert to `ProjDataInMemory` if desired. Fixes problem noted in #686 (which has a misleading title).