### PR TITLE
_storage_scheme -> _default_storage_scheme

### DIFF
--- a/src/common/+sirf/+Utilities/mTest.m
+++ b/src/common/+sirf/+Utilities/mTest.m
@@ -81,5 +81,20 @@ classdef mTest < handle
                 end
             end
         end
+        function check_if_equal(self, expected, value)
+            if value ~= expected
+                self.failed = self.failed + 1;
+                if self.verbose
+                    fprintf...
+                        ('+++ test %d failed: expected %e, got %e\n', ...
+                        self.ntest, expected, value);
+                end
+            else
+                if self.verbose
+                    fprintf('+++ test %d passed\n', self.ntest);
+                end
+            end
+            self.ntest = self.ntest + 1;
+        end
     end
 end

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -241,7 +241,7 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 		if (boost::iequals(name, "AcquisitionData")) {
 
             shared_ptr<PETAcquisitionData> sptr;
-            if (PETAcquisitionData::storage_scheme().compare("file") == 0)
+            if (PETAcquisitionData::default_storage_scheme().compare("file") == 0)
                 sptr.reset(new PETAcquisitionDataInFile(filename));
             else
                 sptr.reset(new PETAcquisitionDataInMemory(filename));
@@ -536,10 +536,18 @@ cSTIR_setAcquisitionDataStorageScheme(const char* scheme)
 
 extern "C"
 void*
-cSTIR_getAcquisitionDataStorageScheme()
+cSTIR_getAcquisitionDataStorageScheme_default()
 {
 	return charDataHandleFromCharData
-		(PETAcquisitionData::storage_scheme().c_str());
+		(PETAcquisitionData::default_storage_scheme().c_str());
+}
+
+extern "C"
+void*
+cSTIR_getAcquisitionDataStorageScheme(const void* ptr_ad)
+{
+    SPTR_FROM_HANDLE(const PETAcquisitionData, ad_sptr, ptr_ad);
+    return charDataHandleFromCharData(ad_sptr->storage_scheme().c_str());
 }
 
 extern "C"

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
@@ -81,7 +81,8 @@ extern "C" {
 		int subset_num, int num_subsets);
 
 	// Acquisition data methods
-	void* cSTIR_getAcquisitionDataStorageScheme();
+	void* cSTIR_getAcquisitionDataStorageScheme_default();
+	void* cSTIR_getAcquisitionDataStorageScheme(const void* ptr_ad);
 	void* cSTIR_setAcquisitionDataStorageScheme(const char* scheme);
 	void* cSTIR_acquisitionDataFromTemplate(void* ptr_t);
 	void* cSTIR_cloneAcquisitionData(void* ptr_ad);

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -169,15 +169,16 @@ namespace sirf {
 			return sptr;
 		}
 
-		static std::string storage_scheme()
+		static std::string default_storage_scheme()
 		{
 			static bool initialized = false;
 			if (!initialized) {
-				_storage_scheme = "file";
+				_default_storage_scheme = "file";
 				initialized = true;
 			}
-			return _storage_scheme;
+			return _default_storage_scheme;
 		}
+		virtual std::string storage_scheme() const = 0;
 		static stir::shared_ptr<PETAcquisitionData> storage_template()
 		{
 			return _template;
@@ -296,7 +297,7 @@ namespace sirf {
 		}
 
 	protected:
-		static std::string _storage_scheme;
+		static std::string _default_storage_scheme;
 		static stir::shared_ptr<PETAcquisitionData> _template;
 		stir::shared_ptr<stir::ProjData> _data;
 		virtual PETAcquisitionData* clone_impl() const = 0;
@@ -358,16 +359,18 @@ namespace sirf {
 		static void init() {
 			static bool initialized = false;
 			if (!initialized) {
-				_storage_scheme = "file";
+				_default_storage_scheme = "file";
 				_template.reset(new PETAcquisitionDataInFile());
 				initialized = true;
-				PETAcquisitionData::storage_scheme();
+				PETAcquisitionData::default_storage_scheme();
 			}
 		}
+		virtual std::string storage_scheme() const 
+		{ return "file"; }
 		static void set_as_template()
 		{
 			init();
-			_storage_scheme = "file";
+			_default_storage_scheme = "file";
 			_template.reset(new PETAcquisitionDataInFile);
 		}
 
@@ -450,10 +453,12 @@ namespace sirf {
 		{ 
 			PETAcquisitionDataInFile::init(); 
 		}
+		virtual std::string storage_scheme() const 
+		{ return "memory"; }
 		static void set_as_template()
 		{
 			init();
-			_storage_scheme = "memory";
+			_default_storage_scheme = "memory";
 			_template.reset(new PETAcquisitionDataInMemory);
 		}
 

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -30,7 +30,7 @@ using namespace sirf;
 //#define DYNAMIC_CAST(T, X, Y) T& X = (T&)Y
 #define DYNAMIC_CAST(T, X, Y) T& X = dynamic_cast<T&>(Y)
 
-std::string PETAcquisitionData::_storage_scheme;
+std::string PETAcquisitionData::_default_storage_scheme;
 shared_ptr<PETAcquisitionData> PETAcquisitionData::_template;
 
 float

--- a/src/xSTIR/mSTIR/+sirf/+STIR/AcquisitionData.m
+++ b/src/xSTIR/mSTIR/+sirf/+STIR/AcquisitionData.m
@@ -43,14 +43,6 @@ classdef AcquisitionData < sirf.SIRF.DataContainer
             sirf.Utilities.check_status('AcquisitionData', h);
             sirf.Utilities.delete(h)
         end
-        function scheme = get_storage_scheme()
-%***SIRF*** Returns current acquisition storage scheme name
-            h = calllib...
-                ('mstir', 'mSTIR_getAcquisitionDataStorageScheme');
-            sirf.Utilities.check_status('AcquisitionData', h);
-            scheme = calllib('miutilities', 'mCharDataFromHandle', h);
-            sirf.Utilities.delete(h)
-        end
     end
     methods
         function self = AcquisitionData...
@@ -115,6 +107,19 @@ classdef AcquisitionData < sirf.SIRF.DataContainer
                 sirf.Utilities.delete(self.handle_)
                 self.handle_ = [];
             end
+        end
+        function scheme = get_storage_scheme(self)
+%***SIRF*** Returns current acquisition storage scheme name
+            if isempty(self.handle_)
+                h = calllib...
+                    ('mstir', 'mSTIR_getAcquisitionDataStorageScheme_default');
+            else
+                h = calllib...
+                    ('mstir', 'mSTIR_getAcquisitionDataStorageScheme', self.handle_);
+            end
+            sirf.Utilities.check_status('AcquisitionData', h);
+            scheme = calllib('miutilities', 'mCharDataFromHandle', h);
+            sirf.Utilities.delete(h)
         end
         function read_from_file(self, filename)
 %***SIRF*** Reads acquisition data from a file.

--- a/src/xSTIR/mSTIR/tests/test1.m
+++ b/src/xSTIR/mSTIR/tests/test1.m
@@ -106,6 +106,14 @@ delta = max(image_array(:))*eps;
 test.check(s)
 test.check(v, delta)
 
+% Check that the storage scheme for a pre-initialised object
+% doesn't change just because the default has changed.
+temp = PET.AcquisitionData();
+temp.set_storage_scheme('memory');
+ad = PET.AcquisitionData(fullfile(pathname, filename));
+temp.set_storage_scheme('file');
+test.check_if_equal('memory', ad.get_storage_scheme());
+
 failed = test.failed;
 ntests = test.ntest;
 

--- a/src/xSTIR/pSTIR/STIR.py.in
+++ b/src/xSTIR/pSTIR/STIR.py.in
@@ -652,11 +652,13 @@ class AcquisitionData(DataContainer):
             (avoid if data is very large)
         '''
         try_calling(pystir.cSTIR_setAcquisitionDataStorageScheme(scheme))
-    @staticmethod
-    def get_storage_scheme():
+    def get_storage_scheme(self=None):
         '''Returns acquisition data storage scheme.
         '''
-        handle = pystir.cSTIR_getAcquisitionDataStorageScheme()
+        if not self:
+            handle = pystir.cSTIR_getAcquisitionDataStorageScheme_default()
+        else:
+            handle = pystir.cSTIR_getAcquisitionDataStorageScheme(self.handle)
         check_status(handle)
         scheme = pyiutil.charDataFromHandle(handle)
         pyiutil.deleteDataHandle(handle)

--- a/src/xSTIR/pSTIR/tests/tests_one.py
+++ b/src/xSTIR/pSTIR/tests/tests_one.py
@@ -155,6 +155,11 @@ def test_main(rec=False, verb=False, throw=True):
     # Test move to scanner centre
     moved_im = image.move_to_scanner_centre(ad)
 
+    AcquisitionData.set_storage_scheme("memory")
+    ad = AcquisitionData(raw_data_file)
+    AcquisitionData.set_storage_scheme("file")
+    test.check_if_equal("memory", ad.get_storage_scheme())
+
     return test.failed, test.ntest
 
 

--- a/src/xSTIR/pSTIR/tests/tests_one.py
+++ b/src/xSTIR/pSTIR/tests/tests_one.py
@@ -155,6 +155,8 @@ def test_main(rec=False, verb=False, throw=True):
     # Test move to scanner centre
     moved_im = image.move_to_scanner_centre(ad)
 
+    # Check that the storage scheme for a pre-initialised object
+    # doesn't change just because the default has changed.
     AcquisitionData.set_storage_scheme("memory")
     ad = AcquisitionData(raw_data_file)
     AcquisitionData.set_storage_scheme("file")


### PR DESCRIPTION
- fixes https://github.com/SyneRBI/SIRF/issues/715.

@evgueni-ovtchinnikov how about this. Change `_storage_scheme` to `_default_storage_scheme`. If using the static method, return the default. However, if the object exists, return the corresponding type.

I've added the test, which fails with the old code, but passes with these changes:
```
    AcquisitionData.set_storage_scheme("memory")
    ad = AcquisitionData(raw_data_file)
    AcquisitionData.set_storage_scheme("file")
    test.check_if_equal("memory", ad.get_storage_scheme())
```