### PR TITLE
get from buffer

### DIFF
--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -695,6 +695,20 @@ void* cSTIR_get_ProjDataInfo(void* ptr_acq)
 }
 
 extern "C"
+void* cSTIR_AcquisitionDataInMemory_get_buffer(void* adim_ptr, size_t out_ptr)
+{
+	try {
+		SPTR_FROM_HANDLE(PETAcquisitionDataInMemory, adim_sptr, adim_ptr);
+        stir::ProjDataInMemory &pdim =
+                dynamic_cast<stir::ProjDataInMemory&>(*adim_sptr->data());
+        float* out_float_ptr = (float*)out_ptr;
+        out_float_ptr = pdim.begin().base();
+        return (void*) new DataHandle;
+	}
+	CATCH;
+}
+
+extern "C"
 void* cSTIR_setupFBP2DReconstruction(void* ptr_r, void* ptr_i)
 {
 	try {

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
@@ -102,6 +102,7 @@ extern "C" {
 		(void* ptr_acq, const void * ptr_from);
 	void* cSTIR_writeAcquisitionData(void* ptr_acq, const char* filename);
 	void* cSTIR_get_ProjDataInfo(void* ptr_acq);
+	void* cSTIR_AcquisitionDataInMemory_get_buffer(void* adim_ptr, PTR_FLOAT out_ptr);
 
 	// Reconstruction methods
 	void* cSTIR_setupFBP2DReconstruction(void* ptr_r, void* ptr_i);

--- a/src/xSTIR/pSTIR/STIR.py.in
+++ b/src/xSTIR/pSTIR/STIR.py.in
@@ -722,9 +722,18 @@ class AcquisitionData(DataContainer):
         - number of tangential positions.
         '''
         assert self.handle is not None
-        array = numpy.ndarray(self.dimensions(), dtype = numpy.float32)
-        try_calling(pystir.cSTIR_getAcquisitionData\
-            (self.handle, array.ctypes.data))
+        # If using file storage scheme, create numpy array and copy data
+        if self.get_storage_scheme() == "file":
+            array = numpy.ndarray(self.dimensions(), dtype = numpy.float32)
+            try_calling(pystir.cSTIR_getAcquisitionData\
+                (self.handle, array.ctypes.data))
+        # If using memory, use a buffer and have a shared object
+        else:
+            buffer = ?
+            try_calling(pystir.cSTIR_AcquisitionDataInMemory_get_buffer\
+                (self.handle, buffer))
+            array = numpy.frombuffer(buffer, dtype=numpy.float32)
+            array.shape = self.dimensions()
         return array
     def fill(self, value):
         ''' 
@@ -744,6 +753,12 @@ class AcquisitionData(DataContainer):
                 v = value.astype(numpy.float32)
             if not v.flags['C_CONTIGUOUS']:
                 v = numpy.ascontiguousarray(v)
+            # If storage_scheme==memory AND numpy array has same address as
+            # C++ buffer, nothing to do!
+            # if self.get_storage_scheme() == 'memory' and :
+                # return
+            
+            # Else, copy from numpy to c++
             try_calling(pystir.cSTIR_setAcquisitionData\
                         (self.handle, v.ctypes.data))
         elif isinstance(value, AcquisitionData):


### PR DESCRIPTION
Just an idea. 

We can use `numpy.frombuffer()` to share data between C++ and python (e.g., for `ProjDataInMemory`). I think all that needs to be done is pass the address of `begin` to the python level. No idea how to do that with your wrapper, though, @evgueni-ovtchinnikov. Any ideas?