### PR TITLE
Run ctest on SIRF demo scripts.

### DIFF
--- a/examples/Python/PET/run_all.py
+++ b/examples/Python/PET/run_all.py
@@ -24,6 +24,8 @@ import sys
 
 for i in sorted(glob.glob('*.py')):
     narg = len(sys.argv)
+    if narg > 1 and (i.find('from') >= 0 or i.find('listmode') >=0):
+        continue
     if os.path.abspath(__file__) == os.path.abspath(i):
         continue
     print('\n=== %s\n' % i)

--- a/src/xSTIR/pSTIR/tests/CMakeLists.txt
+++ b/src/xSTIR/pSTIR/tests/CMakeLists.txt
@@ -21,6 +21,6 @@
 add_test(NAME PET_TESTS_PYTHON
   COMMAND ${Python_EXECUTABLE} -m pytest --cov=sirf.STIR --cov-config=.coveragerc-STIR src/xSTIR/pSTIR/tests
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-#add_test(NAME PET_DEMOS_PYTHON
-#  COMMAND ${PYTHON_EXECUTABLE} run_all.py --non-interactive
-#  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/examples/Python/PET")
+add_test(NAME PET_DEMOS_PYTHON
+  COMMAND ${PYTHON_EXECUTABLE} run_all.py --non-interactive
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/examples/Python/PET")


### PR DESCRIPTION
- Trying again to resolve issue #662.

Travis OSX builds fail if PET demos are run by ctest, apparently because of the Travis 10 min limit for running tests - without PET demos all builds succeed, but every OSX build spends more than 500 sec on SIRF tests.