### PR TITLE
convert a PET sinogram to nifti image

### DIFF
--- a/examples/Python/PET/sirf_sino_as_im_nii.py
+++ b/examples/Python/PET/sirf_sino_as_im_nii.py
@@ -1,0 +1,60 @@
+"""Save a sinogram as a Nifti image. This might
+be useful for observing with an external viewer.
+Geometrical information, such as spacing, is set
+arbitrarily.
+
+
+Usage:
+  sirf_sino_as_im_nii [--help | options]
+
+Options:
+  -s <file>, --sino=<file>  input sinogram
+  -i <path>, --img=<path>   output image [default: im]
+"""
+
+# CCP PETMR Synergistic Image Reconstruction Framework (SIRF)
+# Copyright 2020 University College London.
+#
+# This is software developed for the Collaborative Computational
+# Project in Positron Emission Tomography and Magnetic Resonance imaging
+# (http://www.ccppetmr.ac.uk/).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from sirf.Utilities import error
+import sirf.STIR as pet
+import sirf.Reg as reg
+import numpy as np
+from docopt import docopt
+
+__version__ = '0.1.0'
+args = docopt(__doc__, version=__version__)
+
+# Get filenames
+f_sino = args['--sino']
+f_im = args['--img']
+
+
+def main():
+
+    sino = pet.AcquisitionData(f_sino)
+    image = sino.convert_to_image()
+    reg.ImageData(image).write(f_im)
+
+
+# if anything goes wrong, an exception will be thrown
+# (cf. Error Handling section in the spec)
+try:
+    main()
+    print('done')
+except error as err:
+    # display error information
+    print('%s' % err.value)

--- a/examples/Python/PET/sirf_sino_as_im_nii.py
+++ b/examples/Python/PET/sirf_sino_as_im_nii.py
@@ -1,7 +1,7 @@
-"""Save a sinogram as a Nifti image. This might
-be useful for observing with an external viewer.
-Geometrical information, such as spacing, is set
-arbitrarily.
+"""Save a sinogram as a Nifti image.
+
+This might be useful for observing with an external viewer.
+Geometrical information, such as spacing, is set arbitrarily.
 
 
 Usage:
@@ -32,7 +32,6 @@ Options:
 from sirf.Utilities import error
 import sirf.STIR as pet
 import sirf.Reg as reg
-import numpy as np
 from docopt import docopt
 
 __version__ = '0.1.0'

--- a/src/xSTIR/pSTIR/STIR.py.in
+++ b/src/xSTIR/pSTIR/STIR.py.in
@@ -840,6 +840,16 @@ class AcquisitionData(DataContainer):
         info = pyiutil.charDataFromHandle(handle)
         pyiutil.deleteDataHandle(handle)
         return info
+    def convert_to_image(self):
+        """Convert sinogram to image. This might be useful
+        for visualising with an external viewer. Geometrical
+        information is set arbitrarily."""
+        sino_arr = self.as_array()[1:]
+        dims = sino.dimensions()
+        image = ImageData()
+        image.initialise(dim=dims[1:])
+        image.fill(sino_arr)
+        return image
 ##        print('Please enter sinogram numbers (e.g.: 0, 3-5)')
 ##        print('(a value outside the range 0 to %d will stop this loop)' % \
 ##			(nz - 1))

--- a/src/xSTIR/pSTIR/tests/tests_two.py
+++ b/src/xSTIR/pSTIR/tests/tests_two.py
@@ -110,7 +110,7 @@ def test_main(rec=False, verb=False, throw=True):
         print('acquisitions division (with out=) error: %.1e' % d)
         test.check_if_equal(0, d)
         # Convert sinogram to image (no checks, just ensure no errors thrown)
-        im = acq_data.convert_to_image()
+        acq_data.convert_to_image()
 
         image_copy = image.get_uniform_copy(1.0)
         image_copy *= image

--- a/src/xSTIR/pSTIR/tests/tests_two.py
+++ b/src/xSTIR/pSTIR/tests/tests_two.py
@@ -109,6 +109,8 @@ def test_main(rec=False, verb=False, throw=True):
         d = numpy.linalg.norm(ad2_arr - ad_arr/2)
         print('acquisitions division (with out=) error: %.1e' % d)
         test.check_if_equal(0, d)
+        # Convert sinogram to image (no checks, just ensure no errors thrown)
+        im = acq_data.convert_to_image()
 
         image_copy = image.get_uniform_copy(1.0)
         image_copy *= image


### PR DESCRIPTION
Same as #725. Useful but potentially pollutes the `sirf.STIR.AcquisitionData` class.