### PR TITLE
Reg 2d images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * Iterators are now used in `AcquisitionDataInMemory` to improve speed of `as_array`, `fill`, `dot`, `norm`, etc.
 * Bug fix in `get_index_to_physical_point_matrix`
 * if `storage_scheme` is set to `memory`, then `PETAcquisitionData` will now contain `ProjDataInMemory`, instead of `ProjDataFromStream`. As such, if storage scheme is set to memory, it will now be possible to open a PET acquisition data and modify it directly, whereas before a copy would need to be created first.
+* Registration of 2d images with aladin and f3d. 
+* When registering, internally the forward displacement is no loner stored, replaced by the forward deformation. The inverse is no longer stored, and is calculated as needed.
 
 ## v2.2.0
 * Changed CCP PETMR to SyneRBI

--- a/src/Registration/cReg/NiftiBasedRegistration.cpp
+++ b/src/Registration/cReg/NiftiBasedRegistration.cpp
@@ -46,21 +46,19 @@ void NiftiBasedRegistration<dataType>::convert_to_NiftiImageData_if_not_already(
 }
 
 template<class dataType>
-const std::shared_ptr<const Transformation<dataType> > NiftiBasedRegistration<dataType>::get_deformation_field_forward_sptr(const unsigned idx) const
+const std::shared_ptr<const Transformation<dataType> > NiftiBasedRegistration<dataType>::get_displacement_field_forward_sptr(const unsigned idx) const
 {
-    // Get displacement as NiftiImageData3DDisplacement (from Transformation)
-    std::shared_ptr<const NiftiImageData3DDisplacement<dataType> > disp_fwd = std::dynamic_pointer_cast<const NiftiImageData3DDisplacement<dataType> >(this->get_displacement_field_forward_sptr(idx));
-    std::shared_ptr<NiftiImageData3DDeformation<dataType> > def_fwd = std::make_shared<NiftiImageData3DDeformation<dataType> >(*disp_fwd);
-    return std::move(def_fwd);
+    // Get deformation as NiftiImageData3DDisplacement (from Transformation)
+    std::shared_ptr<const NiftiImageData3DDeformation<dataType> > def_fwd = std::dynamic_pointer_cast<const NiftiImageData3DDeformation<dataType> >(this->get_deformation_field_forward_sptr(idx));
+    return std::move(std::make_shared<NiftiImageData3DDisplacement<dataType> >(*def_fwd));
 }
 
 template<class dataType>
-const std::shared_ptr<const Transformation<dataType> > NiftiBasedRegistration<dataType>::get_deformation_field_inverse_sptr(const unsigned idx) const
+const std::shared_ptr<const Transformation<dataType> > NiftiBasedRegistration<dataType>::get_displacement_field_inverse_sptr(const unsigned idx) const
 {
-    // Get displacement as NiftiImageData3DDisplacement (from Transformation)
-    std::shared_ptr<const NiftiImageData3DDisplacement<dataType> > disp_inv= std::dynamic_pointer_cast<const NiftiImageData3DDisplacement<dataType> >(this->get_displacement_field_inverse_sptr(idx));
-    std::shared_ptr<NiftiImageData3DDeformation<dataType> > def_inv = std::make_shared<NiftiImageData3DDeformation<dataType> >(*disp_inv);
-    return std::move(def_inv);
+    // Get deformation as NiftiImageData3DDisplacement (from Transformation)
+    std::shared_ptr<const NiftiImageData3DDeformation<dataType> > def_inv = std::dynamic_pointer_cast<const NiftiImageData3DDeformation<dataType> >(this->get_deformation_field_inverse_sptr(idx));
+    return std::move(std::make_shared<NiftiImageData3DDisplacement<dataType> >(*def_inv));
 }
 
 namespace sirf {

--- a/src/Registration/cReg/NiftyAladinSym.cpp.in
+++ b/src/Registration/cReg/NiftyAladinSym.cpp.in
@@ -101,7 +101,29 @@ void NiftyAladinSym<dataType>::process()
 
     // Get as deformation and displacement
     NiftiImageData3DDeformation<dataType> def_fwd = _TM_forward_sptr->get_as_deformation_field(ref);
-    NiftiImageData3DDeformation<dataType> def_inv = *def_fwd.get_inverse(this->_floating_images_nifti.at(0));
+    NiftiImageData3DDeformation<dataType> def_inv;
+
+    // Get inverse deformation.
+    bool vtk_available = false;
+#ifdef SIRF_VTK
+    vtk_available = true;
+#endif
+
+    // NiftyReg can only do inverse for 3D images.
+    if (def_fwd.get_raw_nifti_sptr()->nu == 3)
+        def_inv = *def_fwd.get_inverse(this->_floating_images_nifti.at(0));
+    else {
+#ifdef SIRF_VTK
+        // if not 3d but VTK is present, use that.
+        def_inv = *def_fwd.get_inverse(nullptr, true);
+#else
+        // else, throw an error
+        throw std::runtime_error("F3D: Inversion not currently implemented for 2D images with NiftyReg. "
+                                 "This means that you won't be able to get the inverse displacement or "
+                                 "deformation fields. To have these, use a 3D image or install VTK");
+#endif
+    }
+
     this->_disp_fwd_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
     this->_disp_inv_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_inv);
 

--- a/src/Registration/cReg/NiftyAladinSym.cpp.in
+++ b/src/Registration/cReg/NiftyAladinSym.cpp.in
@@ -99,11 +99,7 @@ void NiftyAladinSym<dataType>::process()
     std::cout << "\nPrinting inverse tranformation matrix:\n";
     std::dynamic_pointer_cast<const AffineTransformation<float> >(_TM_inverse_sptr)->print();
 
-    // Get as deformation and displacement
-    NiftiImageData3DDeformation<dataType> def_fwd = _TM_forward_sptr->get_as_deformation_field(ref);
-    NiftiImageData3DDeformation<dataType> def_inv = _TM_inverse_sptr->get_as_deformation_field(*this->_floating_images_nifti.at(0));
-
-    this->_disp_fwd_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
+    this->_def_fwd_images.at(0) = std::make_shared<NiftiImageData3DDeformation<dataType> >(_TM_forward_sptr->get_as_deformation_field(ref));
 
     // Output different dependent on whether image was set as object or via filename
     if (this->_reference_image_sptr) {
@@ -120,13 +116,13 @@ void NiftyAladinSym<dataType>::process()
 template<class dataType>
 const std::shared_ptr<const Transformation<dataType> >
 NiftyAladinSym<dataType>::
-get_displacement_field_inverse_sptr(const unsigned idx) const
+get_deformation_field_inverse_sptr(const unsigned idx) const
 {
     if (idx>0)
-        throw std::runtime_error("NiftyAladinSym::get_displacement_field_inverse_sptr: idx out of range");
+        throw std::runtime_error("NiftyAladinSym::get_deformation_field_inverse_sptr: idx out of range");
 
-    const NiftiImageData3DDeformation<dataType> def_inv = _TM_inverse_sptr->get_as_deformation_field(*this->_floating_images_nifti.at(0));
-    return std::make_shared<NiftiImageData3DDisplacement<float> >(def_inv);
+    return std::make_shared<NiftiImageData3DDeformation<dataType> >(
+                _TM_inverse_sptr->get_as_deformation_field(*this->_floating_images_nifti.at(0)));
 }
 
 template<class dataType>

--- a/src/Registration/cReg/NiftyAladinSym.cpp.in
+++ b/src/Registration/cReg/NiftyAladinSym.cpp.in
@@ -101,31 +101,9 @@ void NiftyAladinSym<dataType>::process()
 
     // Get as deformation and displacement
     NiftiImageData3DDeformation<dataType> def_fwd = _TM_forward_sptr->get_as_deformation_field(ref);
-    NiftiImageData3DDeformation<dataType> def_inv;
-
-    // Get inverse deformation.
-    bool vtk_available = false;
-#ifdef SIRF_VTK
-    vtk_available = true;
-#endif
-
-    // NiftyReg can only do inverse for 3D images.
-    if (def_fwd.get_raw_nifti_sptr()->nu == 3)
-        def_inv = *def_fwd.get_inverse(this->_floating_images_nifti.at(0));
-    else {
-#ifdef SIRF_VTK
-        // if not 3d but VTK is present, use that.
-        def_inv = *def_fwd.get_inverse(nullptr, true);
-#else
-        // else, throw an error
-        throw std::runtime_error("F3D: Inversion not currently implemented for 2D images with NiftyReg. "
-                                 "This means that you won't be able to get the inverse displacement or "
-                                 "deformation fields. To have these, use a 3D image or install VTK");
-#endif
-    }
+    NiftiImageData3DDeformation<dataType> def_inv = _TM_inverse_sptr->get_as_deformation_field(*this->_floating_images_nifti.at(0));
 
     this->_disp_fwd_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
-    this->_disp_inv_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_inv);
 
     // Output different dependent on whether image was set as object or via filename
     if (this->_reference_image_sptr) {
@@ -137,6 +115,18 @@ void NiftyAladinSym<dataType>::process()
         this->_warped_images.at(0) = this->_warped_images_nifti.at(0);
 
     std::cout << "\n\nRegistration finished!\n\n";
+}
+
+template<class dataType>
+const std::shared_ptr<const Transformation<dataType> >
+NiftyAladinSym<dataType>::
+get_displacement_field_inverse_sptr(const unsigned idx) const
+{
+    if (idx>0)
+        throw std::runtime_error("NiftyAladinSym::get_displacement_field_inverse_sptr: idx out of range");
+
+    const NiftiImageData3DDeformation<dataType> def_inv = _TM_inverse_sptr->get_as_deformation_field(*this->_floating_images_nifti.at(0));
+    return std::make_shared<NiftiImageData3DDisplacement<float> >(def_inv);
 }
 
 template<class dataType>

--- a/src/Registration/cReg/NiftyF3dSym.cpp.in
+++ b/src/Registration/cReg/NiftyF3dSym.cpp.in
@@ -116,7 +116,27 @@ void NiftyF3dSym<dataType>::process()
     // Get deformation fields from cpp
     NiftiImageData3DDeformation<dataType> def_fwd, def_inv;
     def_fwd.create_from_cpp(cpp_forward, ref);
-    def_inv = *def_fwd.get_inverse(this->_floating_images_nifti.at(0));
+
+    // Get inverse deformation.
+    bool vtk_available = false;
+#ifdef SIRF_VTK
+    vtk_available = true;
+#endif
+
+    // NiftyReg can only do inverse for 3D images.
+    if (def_fwd.get_raw_nifti_sptr()->nu == 3)
+        def_inv = *def_fwd.get_inverse(this->_floating_images_nifti.at(0));
+    else {
+#ifdef SIRF_VTK
+        // if not 3d but VTK is present, use that.
+        def_inv = *def_fwd.get_inverse(nullptr, true);
+#else
+        // else, throw an error
+        throw std::runtime_error("F3D: Inversion not currently implemented for 2D images with NiftyReg. "
+                                 "This means that you won't be able to get the inverse displacement or "
+                                 "deformation fields. To have these, use a 3D image or install VTK");
+#endif
+    }
 
     // Get the displacement fields from the def
     this->_disp_fwd_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);

--- a/src/Registration/cReg/NiftyF3dSym.cpp.in
+++ b/src/Registration/cReg/NiftyF3dSym.cpp.in
@@ -114,11 +114,9 @@ void NiftyF3dSym<dataType>::process()
     nifti_image_free(cpp_fwd_ptr);
 
     // Get deformation fields from cpp
-    NiftiImageData3DDeformation<dataType> def_fwd;
-    def_fwd.create_from_cpp(cpp_forward, ref);
-
-    // Get the displacement fields from the def
-    this->_disp_fwd_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
+    std::shared_ptr<NiftiImageData3DDeformation<dataType> > def_fwd_sptr = std::make_shared<NiftiImageData3DDeformation<dataType> >();
+    def_fwd_sptr->create_from_cpp(cpp_forward, ref);
+    this->_def_fwd_images.at(0) = def_fwd_sptr;
 
     // Output different dependent on whether image was set as object or via filename
     if (this->_reference_image_sptr) {
@@ -135,16 +133,15 @@ void NiftyF3dSym<dataType>::process()
 template<class dataType>
 const std::shared_ptr<const Transformation<dataType> >
 NiftyF3dSym<dataType>::
-get_displacement_field_inverse_sptr(const unsigned idx) const
+get_deformation_field_inverse_sptr(const unsigned idx) const
 {
     if (idx>0)
         throw std::runtime_error("NiftyF3dSym::get_displacement_field_inverse_sptr: idx out of range");
 
-    NiftiImageData3DDeformation<dataType> def_inv;
-    std::shared_ptr<Transformation<dataType> > trans_fwd = this->_disp_fwd_images.at(0);
-    std::shared_ptr<NiftiImageData3DDisplacement<dataType> > disp_fwd = std::dynamic_pointer_cast<NiftiImageData3DDisplacement<dataType> >(trans_fwd);
-
-    NiftiImageData3DDeformation<dataType> def_fwd(*disp_fwd);
+    std::shared_ptr<NiftiImageData3DDeformation<dataType> > def_inv_sptr;
+    std::shared_ptr<Transformation<dataType> > trans_fwd = this->_def_fwd_images.at(0);
+    const NiftiImageData3DDeformation<dataType> &def_fwd =
+            *std::dynamic_pointer_cast<NiftiImageData3DDeformation<dataType> >(trans_fwd);
 
     // Get inverse deformation.
     bool vtk_available = false;
@@ -154,11 +151,11 @@ get_displacement_field_inverse_sptr(const unsigned idx) const
 
     // NiftyReg can only do inverse for 3D images.
     if (def_fwd.get_raw_nifti_sptr()->nu == 3)
-        def_inv = *def_fwd.get_inverse(this->_floating_images_nifti.at(0));
+        def_inv_sptr = def_fwd.get_inverse(this->_floating_images_nifti.at(0));
     else {
 #ifdef SIRF_VTK
         // if not 3d but VTK is present, use that.
-        def_inv = *def_fwd.get_inverse(nullptr, true);
+        def_inv_sptr = def_fwd.get_inverse(nullptr, true);
 #else
         // else, throw an error
         throw std::runtime_error("F3D: Inversion not currently implemented for 2D images with NiftyReg. "
@@ -166,7 +163,7 @@ get_displacement_field_inverse_sptr(const unsigned idx) const
                                  "deformation fields. To have these, use a 3D image or install VTK");
 #endif
     }
-    return std::make_shared<NiftiImageData3DDisplacement<float> >(def_inv);
+    return def_inv_sptr;
 }
 
 template<class dataType>

--- a/src/Registration/cReg/NiftyF3dSym.cpp.in
+++ b/src/Registration/cReg/NiftyF3dSym.cpp.in
@@ -114,8 +114,37 @@ void NiftyF3dSym<dataType>::process()
     nifti_image_free(cpp_fwd_ptr);
 
     // Get deformation fields from cpp
-    NiftiImageData3DDeformation<dataType> def_fwd, def_inv;
+    NiftiImageData3DDeformation<dataType> def_fwd;
     def_fwd.create_from_cpp(cpp_forward, ref);
+
+    // Get the displacement fields from the def
+    this->_disp_fwd_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
+
+    // Output different dependent on whether image was set as object or via filename
+    if (this->_reference_image_sptr) {
+        // The output should be a clone of the reference image, with data filled in from the nifti image
+        this->_warped_images.at(0) = this->_reference_image_sptr->clone();
+        this->_warped_images.at(0)->fill(*this->_warped_images_nifti.at(0));
+    }
+    else
+        this->_warped_images.at(0) = this->_warped_images_nifti.at(0);
+
+    std::cout << "\n\nRegistration finished!\n\n";
+}
+
+template<class dataType>
+const std::shared_ptr<const Transformation<dataType> >
+NiftyF3dSym<dataType>::
+get_displacement_field_inverse_sptr(const unsigned idx) const
+{
+    if (idx>0)
+        throw std::runtime_error("NiftyF3dSym::get_displacement_field_inverse_sptr: idx out of range");
+
+    NiftiImageData3DDeformation<dataType> def_inv;
+    std::shared_ptr<Transformation<dataType> > trans_fwd = this->_disp_fwd_images.at(0);
+    std::shared_ptr<NiftiImageData3DDisplacement<dataType> > disp_fwd = std::dynamic_pointer_cast<NiftiImageData3DDisplacement<dataType> >(trans_fwd);
+
+    NiftiImageData3DDeformation<dataType> def_fwd(*disp_fwd);
 
     // Get inverse deformation.
     bool vtk_available = false;
@@ -137,21 +166,7 @@ void NiftyF3dSym<dataType>::process()
                                  "deformation fields. To have these, use a 3D image or install VTK");
 #endif
     }
-
-    // Get the displacement fields from the def
-    this->_disp_fwd_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
-    this->_disp_inv_images.at(0) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_inv);
-
-    // Output different dependent on whether image was set as object or via filename
-    if (this->_reference_image_sptr) {
-        // The output should be a clone of the reference image, with data filled in from the nifti image
-        this->_warped_images.at(0) = this->_reference_image_sptr->clone();
-        this->_warped_images.at(0)->fill(*this->_warped_images_nifti.at(0));
-    }
-    else
-        this->_warped_images.at(0) = this->_warped_images_nifti.at(0);
-
-    std::cout << "\n\nRegistration finished!\n\n";
+    return std::make_shared<NiftiImageData3DDisplacement<float> >(def_inv);
 }
 
 template<class dataType>

--- a/src/Registration/cReg/NiftyRegistration.cpp
+++ b/src/Registration/cReg/NiftyRegistration.cpp
@@ -37,7 +37,7 @@ NiftyRegistration<dataType>::NiftyRegistration()
 {
     this->_warped_images.resize(1);
     this->_warped_images_nifti.resize(1);
-    this->_disp_fwd_images.resize(1);
+    this->_def_fwd_images.resize(1);
 }
 
 template<class dataType>

--- a/src/Registration/cReg/NiftyRegistration.cpp
+++ b/src/Registration/cReg/NiftyRegistration.cpp
@@ -38,7 +38,6 @@ NiftyRegistration<dataType>::NiftyRegistration()
     this->_warped_images.resize(1);
     this->_warped_images_nifti.resize(1);
     this->_disp_fwd_images.resize(1);
-    this->_disp_inv_images.resize(1);
 }
 
 template<class dataType>

--- a/src/Registration/cReg/SPMRegistration.cpp
+++ b/src/Registration/cReg/SPMRegistration.cpp
@@ -104,15 +104,15 @@ const std::shared_ptr<const Transformation<dataType> >
 SPMRegistration<dataType>::
 get_displacement_field_inverse_sptr(const unsigned idx) const
 {
+    std::shared_ptr<const NiftiImageData3D<dataType> > floating_sptr;
     if (this->_floating_image_filenames.empty())
-        return this->_disp_inv_images.at(idx);
-    else {
-        auto warped_sptr   = get_output_sptr(idx);
-        auto floating_sptr = std::make_shared<NiftiImageData3D<dataType> >(this->_floating_image_filenames.at(idx));
-        auto def_fwd_sptr  = std::make_shared<NiftiImageData3DDeformation<dataType> >(_TMs_fwd.at(idx)->get_as_deformation_field(*warped_sptr));
-        auto def_inv_sptr  = def_fwd_sptr->get_inverse(floating_sptr);
-        return std::make_shared<NiftiImageData3DDisplacement<dataType> >(*def_inv_sptr);
-    }
+        floating_sptr = this->_floating_images_nifti.at(idx);
+    else
+        floating_sptr = std::make_shared<NiftiImageData3D<dataType> >(this->_floating_image_filenames.at(idx));
+
+    NiftiImageData3DDeformation<dataType> def_inv = _TMs_inv.at(idx)->get_as_deformation_field(*floating_sptr);
+    std::shared_ptr<NiftiImageData3DDisplacement<dataType> > disp_inv_sptr = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_inv);
+    return disp_inv_sptr;
 }
 
 template<class dataType>
@@ -216,12 +216,9 @@ void SPMRegistration<dataType>::process()
 
         // Get as deformation and displacement
         this->_disp_fwd_images.resize(num_flo_ims);
-        this->_disp_inv_images.resize(num_flo_ims);
         for (unsigned i=0; i<num_flo_ims; ++i) {
             NiftiImageData3DDeformation<dataType> def_fwd = _TMs_fwd.at(i)->get_as_deformation_field(*this->_reference_image_nifti_sptr);
-            NiftiImageData3DDeformation<dataType> def_inv = *def_fwd.get_inverse(this->_floating_images_nifti.at(i));
             this->_disp_fwd_images.at(i) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
-            this->_disp_inv_images.at(i) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_inv);
         }
         // The output should be a clone of the reference image, with data filled in from the nifti image
         this->_warped_images.resize(num_flo_ims);

--- a/src/Registration/cReg/SPMRegistration.cpp
+++ b/src/Registration/cReg/SPMRegistration.cpp
@@ -88,21 +88,20 @@ get_output_sptr(const unsigned idx) const
 template<class dataType>
 const std::shared_ptr<const Transformation<dataType> >
 SPMRegistration<dataType>::
-get_displacement_field_forward_sptr(const unsigned idx) const
+get_deformation_field_forward_sptr(const unsigned idx) const
 {
     if (this->_floating_image_filenames.empty())
-        return this->_disp_fwd_images.at(idx);
+        return this->_def_fwd_images.at(idx);
     else {
         auto warped_sptr   = std::make_shared<NiftiImageData3D<dataType> >(this->_resliced_filenames.at(idx));
-        auto def_fwd_sptr  = std::make_shared<NiftiImageData3DDeformation<dataType> >(_TMs_fwd.at(idx)->get_as_deformation_field(*warped_sptr));
-        return std::make_shared<NiftiImageData3DDisplacement<dataType> >(*def_fwd_sptr);
+        return std::make_shared<NiftiImageData3DDeformation<dataType> >(_TMs_fwd.at(idx)->get_as_deformation_field(*warped_sptr));
     }
 }
 
 template<class dataType>
 const std::shared_ptr<const Transformation<dataType> >
 SPMRegistration<dataType>::
-get_displacement_field_inverse_sptr(const unsigned idx) const
+get_deformation_field_inverse_sptr(const unsigned idx) const
 {
     std::shared_ptr<const NiftiImageData3D<dataType> > floating_sptr;
     if (this->_floating_image_filenames.empty())
@@ -110,9 +109,7 @@ get_displacement_field_inverse_sptr(const unsigned idx) const
     else
         floating_sptr = std::make_shared<NiftiImageData3D<dataType> >(this->_floating_image_filenames.at(idx));
 
-    NiftiImageData3DDeformation<dataType> def_inv = _TMs_inv.at(idx)->get_as_deformation_field(*floating_sptr);
-    std::shared_ptr<NiftiImageData3DDisplacement<dataType> > disp_inv_sptr = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_inv);
-    return disp_inv_sptr;
+    return std::make_shared<NiftiImageData3DDeformation<dataType> >(_TMs_inv.at(idx)->get_as_deformation_field(*floating_sptr));
 }
 
 template<class dataType>
@@ -215,11 +212,12 @@ void SPMRegistration<dataType>::process()
             this->_warped_images_nifti.at(i) = std::make_shared<NiftiImageData3D<dataType> >(_resliced_filenames.at(i));
 
         // Get as deformation and displacement
-        this->_disp_fwd_images.resize(num_flo_ims);
-        for (unsigned i=0; i<num_flo_ims; ++i) {
-            NiftiImageData3DDeformation<dataType> def_fwd = _TMs_fwd.at(i)->get_as_deformation_field(*this->_reference_image_nifti_sptr);
-            this->_disp_fwd_images.at(i) = std::make_shared<NiftiImageData3DDisplacement<dataType> >(def_fwd);
-        }
+        this->_def_fwd_images.resize(num_flo_ims);
+        for (unsigned i=0; i<num_flo_ims; ++i)
+            this->_def_fwd_images.at(i) =
+                std::make_shared<NiftiImageData3DDisplacement<dataType> >(
+                    _TMs_fwd.at(i)->get_as_deformation_field(*this->_reference_image_nifti_sptr));
+
         // The output should be a clone of the reference image, with data filled in from the nifti image
         this->_warped_images.resize(num_flo_ims);
         for (unsigned i=0; i<num_flo_ims; ++i) {

--- a/src/Registration/cReg/include/sirf/Reg/NiftiBasedRegistration.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftiBasedRegistration.h
@@ -54,11 +54,11 @@ public:
     /// Destructor
     virtual ~NiftiBasedRegistration() {}
 
-    /// Get forward deformation field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_forward_sptr(const unsigned idx = 0) const;
+    /// Get forward displacement field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_forward_sptr(const unsigned idx = 0) const;
 
-    /// Get inverse deformation field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_inverse_sptr(const unsigned idx = 0) const;
+    /// Get inverse displacement field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const;
 
     /// Convert an ImageData to NiftiImageData. Try to dynamic pointer cast, else create new image.
     static void convert_to_NiftiImageData_if_not_already(std::shared_ptr<const NiftiImageData3D<dataType> > &output_sptr, const std::shared_ptr<const ImageData> &input_sptr);

--- a/src/Registration/cReg/include/sirf/Reg/NiftyAladinSym.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyAladinSym.h
@@ -60,8 +60,8 @@ public:
     /// Get inverse transformation matrix
     const std::shared_ptr<const AffineTransformation<float> > get_transformation_matrix_inverse_sptr() const { return _TM_inverse_sptr; }
 
-    /// Get inverse displacement field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const;
+    /// Get inverse deformation field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_inverse_sptr(const unsigned idx = 0) const;
 
     /// Print all wrapped methods
     static void print_all_wrapped_methods();

--- a/src/Registration/cReg/include/sirf/Reg/NiftyAladinSym.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyAladinSym.h
@@ -60,6 +60,9 @@ public:
     /// Get inverse transformation matrix
     const std::shared_ptr<const AffineTransformation<float> > get_transformation_matrix_inverse_sptr() const { return _TM_inverse_sptr; }
 
+    /// Get inverse displacement field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const;
+
     /// Print all wrapped methods
     static void print_all_wrapped_methods();
 

--- a/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
@@ -81,8 +81,8 @@ public:
     /// Set initial affine transformation
     void set_initial_affine_transformation(const std::shared_ptr<const AffineTransformation<float> > mat) { _initial_transformation_sptr = mat; }
 
-    /// Get inverse displacement field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const;
+    /// Get inverse deformation field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_inverse_sptr(const unsigned idx = 0) const;
 
     /// Print all wrapped methods
     static void print_all_wrapped_methods();

--- a/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftyF3dSym.h
@@ -81,6 +81,9 @@ public:
     /// Set initial affine transformation
     void set_initial_affine_transformation(const std::shared_ptr<const AffineTransformation<float> > mat) { _initial_transformation_sptr = mat; }
 
+    /// Get inverse displacement field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const;
+
     /// Print all wrapped methods
     static void print_all_wrapped_methods();
 

--- a/src/Registration/cReg/include/sirf/Reg/Registration.h
+++ b/src/Registration/cReg/include/sirf/Reg/Registration.h
@@ -106,13 +106,13 @@ public:
     virtual const std::shared_ptr<const ImageData> get_output_sptr(const unsigned idx = 0) const { return _warped_images.at(idx); }
 
     /// Get forward deformation field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_forward_sptr(const unsigned idx = 0) const = 0;
+    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_forward_sptr(const unsigned idx = 0) const { return _def_fwd_images.at(idx); }
 
     /// Get inverse deformation field image
     virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_inverse_sptr(const unsigned idx = 0) const = 0;
 
     /// Get forward displacement field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_forward_sptr(const unsigned idx = 0) const { return _disp_fwd_images.at(idx); }
+    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_forward_sptr(const unsigned idx = 0) const = 0;
 
     /// Get inverse displacement field image
     virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const = 0;
@@ -129,8 +129,8 @@ protected:
     /// Warped image
     std::vector<std::shared_ptr<ImageData> > _warped_images;
 
-    /// Forward displacement field image
-    std::vector<std::shared_ptr<Transformation<dataType> > > _disp_fwd_images;
+    /// Forward deformation field image
+    std::vector<std::shared_ptr<Transformation<dataType> > > _def_fwd_images;
 
     /// Reference image filename
     std::string _reference_image_filename = "";

--- a/src/Registration/cReg/include/sirf/Reg/Registration.h
+++ b/src/Registration/cReg/include/sirf/Reg/Registration.h
@@ -115,7 +115,7 @@ public:
     virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_forward_sptr(const unsigned idx = 0) const { return _disp_fwd_images.at(idx); }
 
     /// Get inverse displacement field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const { return _disp_inv_images.at(idx); }
+    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const = 0;
 
 protected:
 
@@ -131,8 +131,6 @@ protected:
 
     /// Forward displacement field image
     std::vector<std::shared_ptr<Transformation<dataType> > > _disp_fwd_images;
-    /// Inverse displacement field image
-    std::vector<std::shared_ptr<Transformation<dataType> > > _disp_inv_images;
 
     /// Reference image filename
     std::string _reference_image_filename = "";

--- a/src/Registration/cReg/include/sirf/Reg/SPMRegistration.h
+++ b/src/Registration/cReg/include/sirf/Reg/SPMRegistration.h
@@ -72,11 +72,11 @@ public:
     /// Get inverse transformation matrix
     virtual const std::shared_ptr<const AffineTransformation<float> > get_transformation_matrix_inverse_sptr(const unsigned idx = 0) const { return _TMs_inv.at(idx); }
 
-    /// Get forward displacement field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_forward_sptr(const unsigned idx = 0) const;
+    /// Get forward deformation field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_forward_sptr(const unsigned idx = 0) const;
 
-    /// Get inverse displacement field image
-    virtual const std::shared_ptr<const Transformation<dataType> > get_displacement_field_inverse_sptr(const unsigned idx = 0) const;
+    /// Get inverse deformation field image
+    virtual const std::shared_ptr<const Transformation<dataType> > get_deformation_field_inverse_sptr(const unsigned idx = 0) const;
 
 protected:
 

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -880,6 +880,24 @@ int main(int argc, char* argv[])
         if (*NF2.get_output_sptr() != *ref_f3d_crop)
             throw std::runtime_error("NiftyF3dSym failed: ref==flo, but registered image != ref");
 
+        // Check 2D registration
+        {
+            // Create 2D images
+            int crop_for_2D_min[7] = { -1, -1, 0, 0, 0, 0, 0 };
+            int crop_for_2D_max[7] = { -1, -1, 0, 0, 0, 0, 0 };
+            std::shared_ptr<NiftiImageData3D<float> > ref_2d_sptr = ref_f3d->clone();
+            std::shared_ptr<NiftiImageData3D<float> > flo_2d_sptr = flo_f3d->clone();
+            ref_2d_sptr->crop(crop_for_2D_min,crop_for_2D_max);
+            flo_2d_sptr->crop(crop_for_2D_min,crop_for_2D_max);
+            NiftyF3dSym<float> NF_2D;
+            NF_2D.set_reference_image(ref_2d_sptr);
+            NF_2D.set_floating_image (flo_2d_sptr);
+            NF_2D.set_parameter_file( parameter_file_f3d );
+            NF_2D.set_reference_time_point(1);
+            NF_2D.set_floating_time_point(1);
+            NF_2D.process();
+        }
+
         std::cout << "// ----------------------------------------------------------------------- //\n";
         std::cout << "//                  Finished Nifty f3d test.\n";
         std::cout << "//------------------------------------------------------------------------ //\n";

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -814,6 +814,26 @@ int main(int argc, char* argv[])
         if (*out1_sptr != *out2_sptr)
             throw std::runtime_error("NiftiImageData3DDeformation::get_inverse() failed.");
 
+        // Check 2D registration
+        {
+            // Create 2D images
+            int mid_z = int(ref_aladin->get_dimensions()[3]/2);
+            int crop_for_2D_min[7] = { -1, -1, mid_z, 0, 0, 0, 0 };
+            int crop_for_2D_max[7] = { -1, -1, mid_z, 0, 0, 0, 0 };
+            std::shared_ptr<NiftiImageData3D<float> > ref_2d_sptr = ref_aladin->clone();
+            ref_2d_sptr->crop(crop_for_2D_min,crop_for_2D_max);
+            NiftyAladinSym<float> NA_2D;
+            NA_2D.set_reference_image(ref_2d_sptr);
+            NA_2D.set_floating_image (ref_2d_sptr);
+            NA_2D.set_parameter_file (      parameter_file_aladin    );
+            NA_2D.set_parameter("SetInterpolationToCubic");
+            NA_2D.set_parameter("SetLevelsToPerform","1");
+            NA_2D.set_parameter("SetMaxIterations","5");
+            NA_2D.set_parameter("SetPerformRigid","1");
+            NA_2D.set_parameter("SetPerformAffine","0");
+            NA_2D.process();
+        }
+
         std::cout << "// ----------------------------------------------------------------------- //\n";
         std::cout << "//                  Finished Nifty aladin test.\n";
         std::cout << "//------------------------------------------------------------------------ //\n";
@@ -883,8 +903,9 @@ int main(int argc, char* argv[])
         // Check 2D registration
         {
             // Create 2D images
-            int crop_for_2D_min[7] = { -1, -1, 0, 0, 0, 0, 0 };
-            int crop_for_2D_max[7] = { -1, -1, 0, 0, 0, 0, 0 };
+            int mid_z = int(ref_f3d->get_dimensions()[3]/2);
+            int crop_for_2D_min[7] = { -1, -1, mid_z, 0, 0, 0, 0 };
+            int crop_for_2D_max[7] = { -1, -1, mid_z, 0, 0, 0, 0 };
             std::shared_ptr<NiftiImageData3D<float> > ref_2d_sptr = ref_f3d->clone();
             std::shared_ptr<NiftiImageData3D<float> > flo_2d_sptr = flo_f3d->clone();
             ref_2d_sptr->crop(crop_for_2D_min,crop_for_2D_max);

--- a/src/Registration/cReg/tests/test_cReg.cpp
+++ b/src/Registration/cReg/tests/test_cReg.cpp
@@ -408,9 +408,9 @@ int main(int argc, char* argv[])
             throw std::runtime_error("NiftiImageData3D constructor from array.");
 
         // Check that 2D images are ok for the 3D class
-        int pad_for_2D_min[7] = { -1, -1, 0, 0, 0, 0, 0 };
-        int pad_for_2D_max[7] = { -1, -1, 0, 0, 0, 0, 0 };
-        b.crop(pad_for_2D_min,pad_for_2D_max);
+        int crop_for_2D_min[7] = { -1, -1, 0, 0, 0, 0, 0 };
+        int crop_for_2D_max[7] = { -1, -1, 0, 0, 0, 0, 0 };
+        b.crop(crop_for_2D_min,crop_for_2D_max);
         b.write(save_nifti_image_2d);
         NiftiImageData3D<float> im_2d(save_nifti_image_2d);
         if (im_2d.get_dimensions()[0] != 2)


### PR DESCRIPTION
allow registration of 2D images. This used to hit an error because we would get the inverse of the deformation field, which isn't implemented for 2D images with NiftyReg. Now, use VTK if available in this case. Else, throw an error.