### PR TITLE
[TRAVIS] add brew upgrade for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,6 +181,9 @@ before_install:
        #tar xzf cmake-*.tar.gz
        #mv cmake-*/CMake.app/Contents/* cmake
        #export PATH="$PWD/cmake/bin:$PATH"
+
+       #now upgrade the whole thing to avoid problems with outdated packages
+       brew upgrade
      )
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
      PY_EXE=python$PYMVER


### PR DESCRIPTION
Travis brew packages are sometimes out of date, causing problems with dependencies. Attempt therefore to call `brew upgrade`. I'm not sure if this should be done before installing anything else or after (currently trying the latter).

Hopefully fixes #753