### PR TITLE
Add max python

### DIFF
--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -64,7 +64,7 @@ class DataContainer(ABC):
             (mn_one.ctypes.data, self.handle, zero.ctypes.data, self.handle)
         check_status(z.handle)
         return z
-#    @abc.abstractmethod
+
     def same_object(self):
         '''
         Returns an object of the same type as self.
@@ -171,6 +171,8 @@ class DataContainer(ABC):
         other: DataContainer
         out:   DataContainer to store the result to.
         '''
+        if not isinstance (other, ( DataContainer , Number, int, float, numpy.float32 )):
+            return NotImplemented
         if isinstance(other , ( Number, int, float, numpy.float32 )):
             tmp = other + numpy.zeros(self.shape, self.dtype)
             other = self.copy()
@@ -267,7 +269,11 @@ class DataContainer(ABC):
         data viewed as vectors.
         other: DataContainer
         '''
-        return self.subtract(other)
+        assert self.handle is not None
+
+        if isinstance(other, (Number, int, float, numpy.float32) ):
+            return self.subtract(other)
+        return NotImplemented
 
     def __mul__(self, other):
         '''

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -271,7 +271,7 @@ class DataContainer(ABC):
         '''
         assert self.handle is not None
 
-        if isinstance(other, (Number, int, float, numpy.float32) ):
+        if isinstance(other, (DataContainer, Number, int, float, numpy.float32) ):
             return self.subtract(other)
         return NotImplemented
 

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -552,10 +552,16 @@ class DataContainer(ABC):
         '''return default type as float32'''
         return numpy.float32
     
+    def max(self):
+        '''returns the max element in the DataContainer'''
+        return numpy.max(self.as_array())
+    
+    
 class ImageData(DataContainer):
     '''
     Image data ABC
     '''
+        
     def equal(self, other):
         '''
         Overloads == for ImageData.

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -127,7 +127,9 @@ class DataContainer(ABC):
         other: DataContainer
         out:   DataContainer to store the result to.
         '''
-        if isinstance(other , ( Number, int, float, numpy.float32 )):
+        if not isinstance (other, ( DataContainer , Number )):
+            return NotImplemented
+        if isinstance(other , Number):
             tmp = other + numpy.zeros(self.shape, self.dtype)
             other = self.copy()
             other.fill(tmp)
@@ -148,7 +150,9 @@ class DataContainer(ABC):
         other: DataContainer
         out:   DataContainer to store the result to.
         '''
-        if isinstance(other , ( Number, int, float, numpy.float32 )):
+        if not isinstance (other, ( DataContainer , Number )):
+            return NotImplemented
+        if isinstance(other , Number ):
             tmp = other + numpy.zeros(self.shape, self.dtype)
             other = self.copy()
             other.fill(tmp)
@@ -171,9 +175,9 @@ class DataContainer(ABC):
         other: DataContainer
         out:   DataContainer to store the result to.
         '''
-        if not isinstance (other, ( DataContainer , Number, int, float, numpy.float32 )):
+        if not isinstance (other, ( DataContainer , Number )):
             return NotImplemented
-        if isinstance(other , ( Number, int, float, numpy.float32 )):
+        if isinstance(other , Number):
             tmp = other + numpy.zeros(self.shape, self.dtype)
             other = self.copy()
             other.fill(tmp)
@@ -243,7 +247,9 @@ class DataContainer(ABC):
         data viewed as vectors.
         other: DataContainer
         '''
-        if isinstance(other , ( Number, int, float, numpy.float32 )):
+        if not isinstance (other, ( DataContainer , Number )):
+            return NotImplemented
+        if isinstance(other , Number):
             tmp = other + numpy.zeros(self.shape, self.dtype)
             other = self.copy()
             other.fill(tmp)
@@ -271,7 +277,7 @@ class DataContainer(ABC):
         '''
         assert self.handle is not None
 
-        if isinstance(other, (DataContainer, Number, int, float, numpy.float32) ):
+        if isinstance(other, (DataContainer, Number) ):
             return self.subtract(other)
         return NotImplemented
 
@@ -316,7 +322,7 @@ class DataContainer(ABC):
             z.handle = pysirf.cSIRF_axpby \
                 (a.ctypes.data, self.handle, zero.ctypes.data, self.handle)
             check_status(z.handle)
-            return z;
+            return z
 
         return NotImplemented
 


### PR DESCRIPTION
closes #797 
addresses #798 for [addition ](github.com/SyneRBI/SIRF/blob/add_max_python/src/common/SIRF.py#L174)and [subtraction](https://github.com/SyneRBI/SIRF/blob/add_max_python/src/common/SIRF.py#L274) and [multiplication](https://github.com/SyneRBI/SIRF/blob/add_max_python/src/common/SIRF.py#L302).

Unfortunately the implementation is different in each method and should be harmonised.

Unittest are currently available as part of [CIL](https://github.com/vais-ral/CCPi-Framework/blob/test_SIRF/Wrappers/Python/test/test_SIRF.py#L150L201) but they really should be part of SIRF. 