### PR TITLE
if NiftiImageData3D, run check

### DIFF
--- a/src/Registration/cReg/AffineTransformation.cpp
+++ b/src/Registration/cReg/AffineTransformation.cpp
@@ -261,7 +261,7 @@ mat44 AffineTransformation<dataType>::get_as_mat44() const
 }
 
 template<class dataType>
-NiftiImageData3DDeformation<dataType> AffineTransformation<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &ref) const
+NiftiImageData3DDeformation<dataType> AffineTransformation<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &ref, const bool) const
 {
     NiftiImageData3DDeformation<dataType> def;
     def.create_from_3D_image(ref);

--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -1712,6 +1712,42 @@ void NiftiImageData<dataType>::divide
 }
 
 template<class dataType>
+void NiftiImageData<dataType>::maximum
+(const DataContainer& a_x, const DataContainer& a_y)
+{
+	const NiftiImageData<dataType>& x = dynamic_cast<const NiftiImageData<dataType>&>(a_x);
+	const NiftiImageData<dataType>& y = dynamic_cast<const NiftiImageData<dataType>&>(a_y);
+
+	// If the result hasn't been initialised, make a clone of one of them
+	if (!this->is_initialised())
+		*this = *x.clone();
+
+	ASSERT(_nifti_image->nvox == x._nifti_image->nvox, "multiply operands size mismatch");
+	ASSERT(_nifti_image->nvox == y._nifti_image->nvox, "multiply operands size mismatch");
+
+	for (unsigned i = 0; i < this->_nifti_image->nvox; ++i)
+		_data[i] = std::max(x._data[i], y._data[i]);
+}
+
+template<class dataType>
+void NiftiImageData<dataType>::minimum
+(const DataContainer& a_x, const DataContainer& a_y)
+{
+	const NiftiImageData<dataType>& x = dynamic_cast<const NiftiImageData<dataType>&>(a_x);
+	const NiftiImageData<dataType>& y = dynamic_cast<const NiftiImageData<dataType>&>(a_y);
+
+	// If the result hasn't been initialised, make a clone of one of them
+	if (!this->is_initialised())
+		*this = *x.clone();
+
+	ASSERT(_nifti_image->nvox == x._nifti_image->nvox, "multiply operands size mismatch");
+	ASSERT(_nifti_image->nvox == y._nifti_image->nvox, "multiply operands size mismatch");
+
+	for (unsigned i = 0; i < this->_nifti_image->nvox; ++i)
+		_data[i] = std::min(x._data[i], y._data[i]);
+}
+
+template<class dataType>
 void NiftiImageData<dataType>::set_up_geom_info()
 {
 #ifndef NDEBUG

--- a/src/Registration/cReg/NiftiImageData3DDeformation.cpp
+++ b/src/Registration/cReg/NiftiImageData3DDeformation.cpp
@@ -67,32 +67,29 @@ void NiftiImageData3DDeformation<dataType>::create_from_cpp(NiftiImageData3DTens
 }
 
 template<class dataType>
-NiftiImageData3DDeformation<dataType> NiftiImageData3DDeformation<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &) const
+NiftiImageData3DDeformation<dataType> NiftiImageData3DDeformation<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &ref, const bool use_ref) const
 {
-    return *this;
-// The following was put in "to allow resampling with different sized grids to reference"
-// Yet it seemed to give erroneous results when using R^-1 * T * R, where T was the deformation and R was a TM that moved from MR to PET gantry.
-// Returnig *this does give expected results in this case. I'm hoping it doesn't break whatever motivated the code below...
-// I'll have to do the same for the displacement field.
-#if 0
-    NiftiImageData3DDeformation<dataType> output_def;
-    output_def.create_from_3D_image(ref);
-    nifti_image * def_ptr = output_def.get_raw_nifti_sptr().get();
+    if (!use_ref)
+        return *this;
+    else {
+        NiftiImageData3DDeformation<dataType> output_def;
+        output_def.create_from_3D_image(ref);
+        nifti_image * def_ptr = output_def.get_raw_nifti_sptr().get();
 
-    // Initialise the deformation field with an identity transformation
-    reg_tools_multiplyValueToImage(def_ptr,def_ptr,0.f);
-    reg_getDeformationFromDisplacement(def_ptr);
-    def_ptr->intent_p1=DEF_FIELD;
+        // Initialise the deformation field with an identity transformation
+        reg_tools_multiplyValueToImage(def_ptr,def_ptr,0.f);
+        reg_getDeformationFromDisplacement(def_ptr);
+        def_ptr->intent_p1=DEF_FIELD;
 
-    // Not marked const so have to copy unfortunately
-    std::shared_ptr<NiftiImageData3DDeformation<dataType> > copy_of_input_def_sptr =
-            this->clone();
+        // Not marked const so have to copy unfortunately
+        std::shared_ptr<NiftiImageData3DDeformation<dataType> > copy_of_input_def_sptr =
+                this->clone();
 
-    reg_defField_compose(copy_of_input_def_sptr->get_raw_nifti_sptr().get(),
-                         def_ptr,
-                         nullptr);
-    return output_def;
-#endif
+        reg_defField_compose(copy_of_input_def_sptr->get_raw_nifti_sptr().get(),
+                            def_ptr,
+                            nullptr);
+        return output_def;
+    }
 }
 
 template<class dataType>
@@ -104,7 +101,7 @@ NiftiImageData3DDeformation<dataType> NiftiImageData3DDeformation<dataType>::com
     NiftiImageData3DDeformation def = transformations.at(0)->get_as_deformation_field(ref);
 
     for (unsigned i=1; i<transformations.size(); ++i) {
-        NiftiImageData3DDeformation temp = transformations.at(i)->get_as_deformation_field(ref);
+        NiftiImageData3DDeformation temp = transformations.at(i)->get_as_deformation_field(ref, false);
         reg_defField_compose(temp.get_raw_nifti_sptr().get(),def.get_raw_nifti_sptr().get(),nullptr);
     }
     return def;

--- a/src/Registration/cReg/NiftiImageData3DDeformation.cpp
+++ b/src/Registration/cReg/NiftiImageData3DDeformation.cpp
@@ -67,8 +67,14 @@ void NiftiImageData3DDeformation<dataType>::create_from_cpp(NiftiImageData3DTens
 }
 
 template<class dataType>
-NiftiImageData3DDeformation<dataType> NiftiImageData3DDeformation<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &ref) const
+NiftiImageData3DDeformation<dataType> NiftiImageData3DDeformation<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &) const
 {
+    return *this;
+// The following was put in "to allow resampling with different sized grids to reference"
+// Yet it seemed to give erroneous results when using R^-1 * T * R, where T was the deformation and R was a TM that moved from MR to PET gantry.
+// Returnig *this does give expected results in this case. I'm hoping it doesn't break whatever motivated the code below...
+// I'll have to do the same for the displacement field.
+#if 0
     NiftiImageData3DDeformation<dataType> output_def;
     output_def.create_from_3D_image(ref);
     nifti_image * def_ptr = output_def.get_raw_nifti_sptr().get();
@@ -86,6 +92,7 @@ NiftiImageData3DDeformation<dataType> NiftiImageData3DDeformation<dataType>::get
                          def_ptr,
                          nullptr);
     return output_def;
+#endif
 }
 
 template<class dataType>

--- a/src/Registration/cReg/NiftiImageData3DDisplacement.cpp
+++ b/src/Registration/cReg/NiftiImageData3DDisplacement.cpp
@@ -57,34 +57,32 @@ void NiftiImageData3DDisplacement<dataType>::create_from_3D_image(const NiftiIma
 }
 
 template<class dataType>
-NiftiImageData3DDeformation<dataType> NiftiImageData3DDisplacement<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &) const
+NiftiImageData3DDeformation<dataType> NiftiImageData3DDisplacement<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &ref, const bool use_ref) const
 {
-    NiftiImageData3DDeformation<dataType> def(*this);
-    return def;
-// The following was put in "to allow resampling with different sized grids to reference"
-// Yet it seemed to give erroneous results when using R^-1 * T * R, where T was the deformation and R was a TM that moved from MR to PET gantry.
-// Returnig *this does give expected results in this case. I'm hoping it doesn't break whatever motivated the code below...
-// I'll have to do the same for the displacement field.
-#if 0
-    NiftiImageData3DDeformation<dataType> output_def;
-    output_def.create_from_3D_image(ref);
-    nifti_image * def_ptr = output_def.get_raw_nifti_sptr().get();
+    if (!use_ref) {
+        NiftiImageData3DDeformation<dataType> def(*this);
+        return def;
+    }
+    else {
+        NiftiImageData3DDeformation<dataType> output_def;
+        output_def.create_from_3D_image(ref);
+        nifti_image * def_ptr = output_def.get_raw_nifti_sptr().get();
 
-    // Initialise the deformation field with an identity transformation
-    reg_tools_multiplyValueToImage(def_ptr,def_ptr,0.f);
-    reg_getDeformationFromDisplacement(def_ptr);
-    def_ptr->intent_p1=DEF_FIELD;
+        // Initialise the deformation field with an identity transformation
+        reg_tools_multiplyValueToImage(def_ptr,def_ptr,0.f);
+        reg_getDeformationFromDisplacement(def_ptr);
+        def_ptr->intent_p1=DEF_FIELD;
 
-    // Not marked const so have to copy unfortunately
-    std::shared_ptr<NiftiImageData3DDisplacement<dataType> > copy_of_input_disp_sptr =
-            this->clone();
-    // Convert displacement to deformation
-    reg_getDeformationFromDisplacement(copy_of_input_disp_sptr->get_raw_nifti_sptr().get());
-    reg_defField_compose(copy_of_input_disp_sptr->get_raw_nifti_sptr().get(),
-                         def_ptr,
-                         nullptr);
-    return output_def;
-#endif
+        // Not marked const so have to copy unfortunately
+        std::shared_ptr<NiftiImageData3DDisplacement<dataType> > copy_of_input_disp_sptr =
+                this->clone();
+        // Convert displacement to deformation
+        reg_getDeformationFromDisplacement(copy_of_input_disp_sptr->get_raw_nifti_sptr().get());
+        reg_defField_compose(copy_of_input_disp_sptr->get_raw_nifti_sptr().get(),
+                            def_ptr,
+                            nullptr);
+        return output_def;
+    }
 }
 
 template<class dataType>

--- a/src/Registration/cReg/NiftiImageData3DDisplacement.cpp
+++ b/src/Registration/cReg/NiftiImageData3DDisplacement.cpp
@@ -57,8 +57,15 @@ void NiftiImageData3DDisplacement<dataType>::create_from_3D_image(const NiftiIma
 }
 
 template<class dataType>
-NiftiImageData3DDeformation<dataType> NiftiImageData3DDisplacement<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &ref) const
+NiftiImageData3DDeformation<dataType> NiftiImageData3DDisplacement<dataType>::get_as_deformation_field(const NiftiImageData<dataType> &) const
 {
+    NiftiImageData3DDeformation<dataType> def(*this);
+    return def;
+// The following was put in "to allow resampling with different sized grids to reference"
+// Yet it seemed to give erroneous results when using R^-1 * T * R, where T was the deformation and R was a TM that moved from MR to PET gantry.
+// Returnig *this does give expected results in this case. I'm hoping it doesn't break whatever motivated the code below...
+// I'll have to do the same for the displacement field.
+#if 0
     NiftiImageData3DDeformation<dataType> output_def;
     output_def.create_from_3D_image(ref);
     nifti_image * def_ptr = output_def.get_raw_nifti_sptr().get();
@@ -77,6 +84,7 @@ NiftiImageData3DDeformation<dataType> NiftiImageData3DDisplacement<dataType>::ge
                          def_ptr,
                          nullptr);
     return output_def;
+#endif
 }
 
 template<class dataType>

--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -450,13 +450,16 @@ void* cReg_NiftiImageData_get_inner_product(const void* im1_ptr, const void* im2
     CATCH;
 }
 extern "C"
-void* cReg_NiftiImageData_from_SIRFImageData(void* ptr)
+void* cReg_NiftiImageData_from_SIRFImageData(void* ptr, const int is_3D)
 {
 	try {
         ImageData& sirf_im = objectFromHandle<ImageData>(ptr);
-        std::shared_ptr<NiftiImageData<float> >
-            sptr(new NiftiImageData<float>(sirf_im));
-        return newObjectHandle(sptr);
+
+    	// Use an int as if bool to optionally run 3D checks
+        if (is_3D == 1)
+        	return newObjectHandle(sptr(new NiftiImageData3D<float>(sirf_im)));
+        else
+        	return newObjectHandle(sptr(new NiftiImageData<float>(sirf_im)));
     }
 	CATCH;
 }

--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -455,11 +455,10 @@ void* cReg_NiftiImageData_from_SIRFImageData(void* ptr, const int is_3D)
     try {
         ImageData& sirf_im = objectFromHandle<ImageData>(ptr);
 
-        // Use an int as if bool to optionally run 3D checks
-        if (is_3D == 1)
-            return newObjectHandle(sptr(new NiftiImageData3D<float>(sirf_im)));
+        if (is_3D)
+          return newObjectHandle(std::make_shared<NiftiImageData3D<float>>(sirf_im));
         else
-            return newObjectHandle(sptr(new NiftiImageData<float>(sirf_im)));
+          return newObjectHandle(std::make_shared<NiftiImageData<float>>(sirf_im));
     }
 	CATCH;
 }

--- a/src/Registration/cReg/cReg.cpp
+++ b/src/Registration/cReg/cReg.cpp
@@ -452,14 +452,14 @@ void* cReg_NiftiImageData_get_inner_product(const void* im1_ptr, const void* im2
 extern "C"
 void* cReg_NiftiImageData_from_SIRFImageData(void* ptr, const int is_3D)
 {
-	try {
+    try {
         ImageData& sirf_im = objectFromHandle<ImageData>(ptr);
 
-    	// Use an int as if bool to optionally run 3D checks
+        // Use an int as if bool to optionally run 3D checks
         if (is_3D == 1)
-        	return newObjectHandle(sptr(new NiftiImageData3D<float>(sirf_im)));
+            return newObjectHandle(sptr(new NiftiImageData3D<float>(sirf_im)));
         else
-        	return newObjectHandle(sptr(new NiftiImageData<float>(sirf_im)));
+            return newObjectHandle(sptr(new NiftiImageData<float>(sirf_im)));
     }
 	CATCH;
 }

--- a/src/Registration/cReg/include/sirf/Reg/AffineTransformation.h
+++ b/src/Registration/cReg/include/sirf/Reg/AffineTransformation.h
@@ -98,8 +98,12 @@ public:
     /// Destructor
     virtual ~AffineTransformation() {}
 
-    /// Get as deformation field
-    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &ref) const;
+    /// Get as deformation field.
+    ///
+    /// Reference image **must** be used when converting a transformation matrix to a deformation.
+    /// For displacements and deformations, the reference can be used optionally. It **should** be used when composing transformations to be used for resampling
+    /// But is probably unnecessary for simply concatenating deformations.
+    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &ref, const bool use_ref = true) const;
 
     /// Deep copy
     virtual AffineTransformation deep_copy() const;

--- a/src/Registration/cReg/include/sirf/Reg/NiftiImageData.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftiImageData.h
@@ -607,7 +607,9 @@ protected:
     virtual float norm() const;
     virtual void multiply (const DataContainer& a_x, const DataContainer& a_y);
     virtual void divide   (const DataContainer& a_x, const DataContainer& a_y);
-    virtual Dimensions dimensions() const
+	virtual void maximum(const DataContainer& x, const DataContainer& y);
+	virtual void minimum(const DataContainer& x, const DataContainer& y);
+	virtual Dimensions dimensions() const
     {
         Dimensions dim;
         int *d = _nifti_image->dim;

--- a/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDeformation.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDeformation.h
@@ -91,7 +91,7 @@ public:
     virtual NiftiImageData3DDeformation get_as_deformation_field(const NiftiImageData<dataType> &ref) const;
 
     /// Compose multiple transformations into single deformation field
-    static NiftiImageData3DDeformation compose_single_deformation(const std::vector<const Transformation<dataType> *> &transformations, const NiftiImageData<dataType> &ref);
+    static NiftiImageData3DDeformation compose_single_deformation(const std::vector<const Transformation<dataType> *> &transformations, const NiftiImageData<dataType> &);
 
     /// Compose multiple transformations into single deformation field
     static NiftiImageData3DDeformation compose_single_deformation(const std::vector<std::shared_ptr<const Transformation<dataType> > > &transformations, const NiftiImageData<dataType> &ref);

--- a/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDeformation.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDeformation.h
@@ -87,11 +87,15 @@ public:
     /// Create from control point grid image
     void create_from_cpp(NiftiImageData3DTensor<dataType> &cpp, const NiftiImageData<dataType> &ref);
 
-    /// Get as deformation field
-    virtual NiftiImageData3DDeformation get_as_deformation_field(const NiftiImageData<dataType> &ref) const;
+    /// Get as deformation field.
+    ///
+    /// Reference image **must** be used when converting a transformation matrix to a deformation.
+    /// For displacements and deformations, the reference can be used optionally. It **should** be used when composing transformations to be used for resampling
+    /// But is probably unnecessary for simply concatenating deformations.
+    virtual NiftiImageData3DDeformation get_as_deformation_field(const NiftiImageData<dataType> &ref, const bool use_ref = true) const;
 
     /// Compose multiple transformations into single deformation field
-    static NiftiImageData3DDeformation compose_single_deformation(const std::vector<const Transformation<dataType> *> &transformations, const NiftiImageData<dataType> &);
+    static NiftiImageData3DDeformation compose_single_deformation(const std::vector<const Transformation<dataType> *> &transformations, const NiftiImageData<dataType> &ref);
 
     /// Compose multiple transformations into single deformation field
     static NiftiImageData3DDeformation compose_single_deformation(const std::vector<std::shared_ptr<const Transformation<dataType> > > &transformations, const NiftiImageData<dataType> &ref);

--- a/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDisplacement.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDisplacement.h
@@ -83,7 +83,7 @@ public:
     void create_from_3D_image(const NiftiImageData<dataType> &image);
 
     /// Get as deformation field
-    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &ref) const;
+    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &) const;
 
     virtual ObjectHandle<DataContainer>* new_data_container_handle() const
     {

--- a/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDisplacement.h
+++ b/src/Registration/cReg/include/sirf/Reg/NiftiImageData3DDisplacement.h
@@ -82,8 +82,12 @@ public:
     /// Create from 3D image (fill with zeroes)
     void create_from_3D_image(const NiftiImageData<dataType> &image);
 
-    /// Get as deformation field
-    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &) const;
+    /// Get as deformation field.
+    ///
+    /// Reference image **must** be used when converting a transformation matrix to a deformation.
+    /// For displacements and deformations, the reference can be used optionally. It **should** be used when composing transformations to be used for resampling
+    /// But is probably unnecessary for simply concatenating deformations.
+    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &ref, const bool use_ref = true) const;
 
     virtual ObjectHandle<DataContainer>* new_data_container_handle() const
     {

--- a/src/Registration/cReg/include/sirf/Reg/Transformation.h
+++ b/src/Registration/cReg/include/sirf/Reg/Transformation.h
@@ -58,8 +58,12 @@ public:
     /// Destructor
     virtual ~Transformation() {}
 
-    /// Get as deformation field
-    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &ref) const = 0;
+    /// Get as deformation field.
+    ///
+    /// Reference image **must** be used when converting a transformation matrix to a deformation.
+    /// For displacements and deformations, the reference can be used optionally. It **should** be used when composing transformations to be used for resampling
+    /// But is probably unnecessary for simply concatenating deformations.
+    virtual NiftiImageData3DDeformation<dataType> get_as_deformation_field(const NiftiImageData<dataType> &ref, const bool use_ref = true) const = 0;
 
     /// Write
     virtual void write(const std::string &filename) const = 0;

--- a/src/Registration/cReg/include/sirf/Reg/cReg.h
+++ b/src/Registration/cReg/include/sirf/Reg/cReg.h
@@ -59,6 +59,8 @@ extern "C" {
     void* cReg_NiftiImageData_normalise_zero_and_one(const void* im_ptr);
     void* cReg_NiftiImageData_standardise(const void* im_ptr);
     void* cReg_NiftiImageData_get_inner_product(const void* im1_ptr, const void* im2_ptr);
+    //!  create NiftiImage or NiftiImageData3D
+    /*! Use an \c int as \c bool to create a 3D image (running 3D checks) */
     void* cReg_NiftiImageData_from_SIRFImageData(void* ptr, const int is_3D);
     void* cReg_NiftiImageData_from_complex_ImageData_real_component(void* in_ptr);
     void* cReg_NiftiImageData_from_complex_ImageData_imag_component(void* in_ptr);

--- a/src/Registration/cReg/include/sirf/Reg/cReg.h
+++ b/src/Registration/cReg/include/sirf/Reg/cReg.h
@@ -59,7 +59,7 @@ extern "C" {
     void* cReg_NiftiImageData_normalise_zero_and_one(const void* im_ptr);
     void* cReg_NiftiImageData_standardise(const void* im_ptr);
     void* cReg_NiftiImageData_get_inner_product(const void* im1_ptr, const void* im2_ptr);
-    void* cReg_NiftiImageData_from_SIRFImageData(void* ptr);
+    void* cReg_NiftiImageData_from_SIRFImageData(void* ptr, const int is_3D);
     void* cReg_NiftiImageData_from_complex_ImageData_real_component(void* in_ptr);
     void* cReg_NiftiImageData_from_complex_ImageData_imag_component(void* in_ptr);
     void* cReg_NiftiImageData_are_equal_to_given_accuracy(void* im1_ptr, void* im2_ptr, const float accuracy);

--- a/src/Registration/mReg/+sirf/+Reg/NiftiImageData.m
+++ b/src/Registration/mReg/+sirf/+Reg/NiftiImageData.m
@@ -38,7 +38,7 @@ classdef NiftiImageData < sirf.SIRF.ImageData
             elseif ischar(src)
                 self.handle_ = calllib('mreg', 'mReg_objectFromFile', self.name, src);
             elseif isa(src, 'sirf.SIRF.ImageData')
-                self.handle_ = calllib('mreg', 'mReg_NiftiImageData_from_SIRFImageData', src.handle_);
+                self.handle_ = calllib('mreg', 'mReg_NiftiImageData_from_SIRFImageData', src.handle_, 0);
             else
                 error('NiftiImageData accepts no args, filename or sirf.SIRF.ImageData.')
             end

--- a/src/Registration/mReg/+sirf/+Reg/NiftiImageData3D.m
+++ b/src/Registration/mReg/+sirf/+Reg/NiftiImageData3D.m
@@ -35,7 +35,7 @@ classdef NiftiImageData3D < sirf.Reg.NiftiImageData
             elseif ischar(src)
                 self.handle_ = calllib('mreg', 'mReg_objectFromFile', self.name, src);
             elseif isa(src, 'sirf.SIRF.ImageData')
-                self.handle_ = calllib('mreg', 'mReg_NiftiImageData_from_SIRFImageData', src.handle_);
+                self.handle_ = calllib('mreg', 'mReg_NiftiImageData_from_SIRFImageData', src.handle_, 1);
             else
                 error('NiftiImageData3D accepts no args, filename or sirf.SIRF.ImageData.')
             end

--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -162,7 +162,7 @@ class NiftiImageData(SIRF.ImageData):
         elif isinstance(src, SIRF.ImageData):
             # src is ImageData
             self.handle = pyreg.cReg_NiftiImageData_from_SIRFImageData(
-                src.handle)
+                src.handle, 0)
         else:
             raise error('Wrong source in NiftiImageData constructor')
         check_status(self.handle)
@@ -560,7 +560,7 @@ class NiftiImageData3D(NiftiImageData):
         elif isinstance(src, SIRF.ImageData):
             # src is ImageData
             self.handle = pyreg.cReg_NiftiImageData_from_SIRFImageData(
-                src.handle)
+                src.handle, 1)
         else:
             raise error('Wrong source in NiftiImageData3D constructor')
         check_status(self.handle)

--- a/src/Registration/pReg/tests/test_pReg.py
+++ b/src/Registration/pReg/tests/test_pReg.py
@@ -353,18 +353,25 @@ def try_niftiimage3d():
         raise AssertionError("NiftiImageData3D deep_copy failed.")
 
     # Constructor
-    dd = NiftiImageData3D(b)
+    dd = sirf.Reg.NiftiImageData3D(b)
     if dd.handle == b.handle:
         raise AssertionError('NiftiImageData3D constructor failed (handle).')
     if dd != b:
         raise AssertionError("NiftiImageData3D constructor failed.")
 
-    ddd = sirf.Reg.NiftiDeformationField(ref_f3d_filename)
     try:
-        dddd = NiftiImageData3D(ddd)
+        sirf.Reg.NiftiImageData3DDeformation(ref_f3d_filename)
+        raise AssertionError('NiftiImageData3DDeformation constructor should have thrown with filename for 3D image')
+    except:
+        pass # ok
+
+    ddd = sirf.Reg.NiftiImageData3DDeformation()
+    ddd.create_from_3D_image(ref_aladin)
+    try:
+        dddd = sirf.Reg.NiftiImageData3D(ddd)
         raise AssertionError('NiftiImageData3D constructor should have thrown with 4D image')
     except:
-        # ok
+        pass # ok
 
     # Addition
     e = d + d

--- a/src/Registration/pReg/tests/test_pReg.py
+++ b/src/Registration/pReg/tests/test_pReg.py
@@ -363,7 +363,7 @@ def try_niftiimage3d():
     try:
         dddd = NiftiImageData3D(ddd)
         raise AssertionError('NiftiImageData3D constructor should have thrown with 4D image')
-    catch:
+    except:
         # ok
 
     # Addition

--- a/src/Registration/pReg/tests/test_pReg.py
+++ b/src/Registration/pReg/tests/test_pReg.py
@@ -348,9 +348,23 @@ def try_niftiimage3d():
     # Deep copy
     d = b.deep_copy()
     if d.handle == b.handle:
-        raise AssertionError('NiftiImageData3D deep_copy failed.')
+        raise AssertionError('NiftiImageData3D deep_copy failed (handle).')
     if d != b:
         raise AssertionError("NiftiImageData3D deep_copy failed.")
+
+    # Constructor
+    dd = NiftiImageData3D(b)
+    if dd.handle == b.handle:
+        raise AssertionError('NiftiImageData3D constructor failed (handle).')
+    if dd != b:
+        raise AssertionError("NiftiImageData3D constructor failed.")
+
+    ddd = sirf.Reg.NiftiDeformationField(ref_f3d_filename)
+    try:
+        dddd = NiftiImageData3D(ddd)
+        raise AssertionError('NiftiImageData3D constructor should have thrown with 4D image')
+    catch:
+        # ok
 
     # Addition
     e = d + d

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -726,6 +726,7 @@ class GeometricalInfo(object):
         if self.handle is not None:
             pyiutil.deleteDataHandle(self.handle)
 
+    @deprecation.deprecated(details="Please use get_info method instead")
     def print_info(self):
         """Print the geom info"""
         print(self.get_info())

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -36,11 +36,6 @@ import sirf.pysirf as pysirf
 from numbers import Number
 import deprecation
 
-try:
-    input = raw_input
-except NameError:
-    pass
-
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 4:
     ABC = abc.ABC
 else:

--- a/src/common/include/sirf/common/DataContainer.h
+++ b/src/common/include/sirf/common/DataContainer.h
@@ -48,9 +48,13 @@ namespace sirf {
 		virtual float norm() const = 0;
 		virtual void dot(const DataContainer& dc, void* ptr) const = 0;
 		virtual void multiply
-		(const DataContainer& x, const DataContainer& y) = 0;
+			(const DataContainer& x, const DataContainer& y) = 0;
 		virtual void divide
-		(const DataContainer& x, const DataContainer& y) = 0;
+			(const DataContainer& x, const DataContainer& y) = 0;
+		virtual void maximum
+			(const DataContainer& x, const DataContainer& y) = 0;
+		virtual void minimum
+			(const DataContainer& x, const DataContainer& y) = 0;
 		virtual void axpby(
 			const void* ptr_a, const DataContainer& x,
 			const void* ptr_b, const DataContainer& y) = 0;

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -287,12 +287,16 @@ namespace sirf {
 		//{
 		//	axpby(ptr_a, a_x, ptr_b, a_y);
 		//}
-		virtual void multiply(
-			const DataContainer& a_x,
-			const DataContainer& a_y);
-		virtual void divide(
-			const DataContainer& a_x,
-			const DataContainer& a_y);
+		virtual void multiply(const DataContainer& x, const DataContainer& y);
+		virtual void divide(const DataContainer& x,	const DataContainer& y);
+		virtual void maximum(const DataContainer& x, const DataContainer& y)
+		{
+			THROW("maximum not defined for MRAcquisitionData");
+		}
+		virtual void minimum(const DataContainer& x, const DataContainer& y)
+		{
+			THROW("minimum not defined for MRAcquisitionData");
+		}
 		virtual float norm() const;
 
 		virtual void write(const std::string &filename) const;
@@ -576,12 +580,16 @@ namespace sirf {
 			DYNAMIC_CAST(const ISMRMRDImageData, b, a_b);
 			xapyb_(a_x, a, a_y, b);
 		}
-		virtual void multiply(
-			const DataContainer& a_x,
-			const DataContainer& a_y);
-		virtual void divide(
-			const DataContainer& a_x,
-			const DataContainer& a_y);
+		virtual void multiply(const DataContainer& x, const DataContainer& y);
+		virtual void divide(const DataContainer& x, const DataContainer& y);
+		virtual void maximum(const DataContainer& x, const DataContainer& y)
+		{
+			THROW("maximum not defined for ISMRMRDImageData");
+		}
+		virtual void minimum(const DataContainer& x, const DataContainer& y)
+		{
+			THROW("minimum not defined for ISMRMRDImageData");
+		}
 
 		void fill(float s);
 		void scale(float s);

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -293,7 +293,8 @@ class ImageData(SIRF.ImageData):
         images.handle = pygadgetron.cGT_selectImages(self.handle, attr, value)
         check_status(images.handle)
         return images
-    def get_info(self, par):
+
+    def parameter_info(self, par):
         '''
         Returns the array of values of the specified image information 
         parameter. Parameters names are the same as the names of Image class
@@ -306,6 +307,10 @@ class ImageData(SIRF.ImageData):
             image = self.image(i)
             info[i] = image.info(par)
         return info
+
+    @deprecated(details="Please use parameter_info method instead")
+    def get_info(self, par):
+        return self.parameter_info(par)
 
     def fill(self, data):
         '''
@@ -904,7 +909,8 @@ class AcquisitionData(DataContainer):
         pyiutil.deleteDataHandle(hv)
         dim[2] = numpy.prod(dim[2:])
         return tuple(dim[2::-1])
-    def get_info(self, par, which = 'all'):
+
+    def parameter_info(self, par, which='all'):
         '''
         Returns the array of values of the specified acquisition information 
         parameter.
@@ -924,6 +930,11 @@ class AcquisitionData(DataContainer):
             i += 1
 ##            info[a] = acq.info(par)
         return info
+
+    @deprecated(details="Please use parameter_info method instead")
+    def get_info(self, par, which='all'):
+        return self.parameter_info(par, which)
+
     def fill(self, data, select='image'):
         '''
         Fills self's acquisitions with specified values.

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -263,10 +263,22 @@ namespace sirf {
 		virtual void xapyb(
 			const DataContainer& a_x, const DataContainer& a_a,
 			const DataContainer& a_y, const DataContainer& a_b);
-		virtual void multiply
-			(const DataContainer& x, const DataContainer& y);
-		virtual void divide
-			(const DataContainer& x, const DataContainer& y);
+		virtual void multiply(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 1);
+		}
+		virtual void divide(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 2);
+		}
+		virtual void maximum(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 3);
+		}
+		virtual void minimum(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 4);
+		}
 		virtual void inv(float a, const DataContainer& x);
 		virtual void write(const std::string &filename) const
 		{
@@ -377,7 +389,7 @@ namespace sirf {
 
 	private:
 		mutable int _is_empty = -1;
-
+		void binary_op_(const DataContainer& a_x, const DataContainer& a_y, int job);
 	};
 
 	/*!
@@ -908,10 +920,22 @@ namespace sirf {
 		virtual void xapyb(
 			const DataContainer& a_x, const DataContainer& a_a,
 			const DataContainer& a_y, const DataContainer& a_b);
-		virtual void multiply(const DataContainer& x,
-			const DataContainer& y);
-		virtual void divide(const DataContainer& x,
-			const DataContainer& y);
+		virtual void multiply(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 1);
+		}
+		virtual void divide(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 2);
+		}
+		virtual void maximum(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 3);
+		}
+		virtual void minimum(const DataContainer& x, const DataContainer& y)
+		{
+			binary_op_(x, y, 4);
+		}
 
 		Image3DF& data()
 		{
@@ -1032,6 +1056,7 @@ namespace sirf {
         {
             return new STIRImageData(*this);
         }
+		void binary_op_(const DataContainer& a_x, const DataContainer& a_y, int job);
 
 	protected:
 

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -176,13 +176,12 @@ PETAcquisitionData::inv(float amin, const DataContainer& a_x)
 }
 
 void
-PETAcquisitionData::multiply(
-const DataContainer& a_x,
-const DataContainer& a_y
+PETAcquisitionData::binary_op_(
+	const DataContainer& a_x,
+	const DataContainer& a_y,
+	int job
 )
 {
-	//PETAcquisitionData& x = (PETAcquisitionData&)a_x;
-	//PETAcquisitionData& y = (PETAcquisitionData&)a_y;
 	DYNAMIC_CAST(const PETAcquisitionData, x, a_x);
 	DYNAMIC_CAST(const PETAcquisitionData, y, a_y);
 	int n = get_max_segment_num();
@@ -200,53 +199,21 @@ const DataContainer& a_y
 			sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
 			seg_iter != seg.end_all() &&
 			sx_iter != sx.end_all() && sy_iter != sy.end_all();
-		/*empty*/) {
-			*seg_iter++ = (*sx_iter++) * (*sy_iter++);
-		}
-		set_segment(seg);
-		if (s != 0) {
-			seg = get_empty_segment_by_sinogram(-s);
-			sx = x.get_segment_by_sinogram(-s);
-			sy = y.get_segment_by_sinogram(-s);
-			for (seg_iter = seg.begin_all(),
-				sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
-				seg_iter != seg.end_all() &&
-				sx_iter != sx.end_all() && sy_iter != sy.end_all();
 			/*empty*/) {
+			switch (job) {
+			case 1:
 				*seg_iter++ = (*sx_iter++) * (*sy_iter++);
+				break;
+			case 2:
+				*seg_iter++ = (*sx_iter++) / (*sy_iter++);
+				break;
+			case 3:
+				*seg_iter++ = std::max(*sx_iter++, *sy_iter++);
+				break;
+			case 4:
+				*seg_iter++ = std::min(*sx_iter++, *sy_iter++);
+				break;
 			}
-			set_segment(seg);
-		}
-	}
-}
-
-void
-PETAcquisitionData::divide(
-const DataContainer& a_x,
-const DataContainer& a_y
-)
-{
-	//PETAcquisitionData& x = (PETAcquisitionData&)a_x;
-	//PETAcquisitionData& y = (PETAcquisitionData&)a_y;
-	DYNAMIC_CAST(const PETAcquisitionData, x, a_x);
-	DYNAMIC_CAST(const PETAcquisitionData, y, a_y);
-	int n = get_max_segment_num();
-	int nx = x.get_max_segment_num();
-	int ny = y.get_max_segment_num();
-	for (int s = 0; s <= n && s <= nx && s <= ny; ++s)
-	{
-		SegmentBySinogram<float> seg = get_empty_segment_by_sinogram(s);
-		SegmentBySinogram<float> sx = x.get_segment_by_sinogram(s);
-		SegmentBySinogram<float> sy = y.get_segment_by_sinogram(s);
-		SegmentBySinogram<float>::full_iterator seg_iter;
-		SegmentBySinogram<float>::full_iterator sx_iter;
-		SegmentBySinogram<float>::full_iterator sy_iter;
-		for (seg_iter = seg.begin_all(),
-			sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
-			seg_iter != seg.end_all() &&
-			sx_iter != sx.end_all() && sy_iter != sy.end_all();
-		/*empty*/) {
-			*seg_iter++ = (*sx_iter++) / (*sy_iter++);
 		}
 		set_segment(seg);
 		if (s != 0) {
@@ -257,8 +224,21 @@ const DataContainer& a_y
 				sx_iter = sx.begin_all(), sy_iter = sy.begin_all();
 				seg_iter != seg.end_all() &&
 				sx_iter != sx.end_all() && sy_iter != sy.end_all();
-			/*empty*/) {
-				*seg_iter++ = (*sx_iter++) / (*sy_iter++);
+				/*empty*/) {
+				switch (job) {
+				case 1:
+					*seg_iter++ = (*sx_iter++) * (*sy_iter++);
+					break;
+				case 2:
+					*seg_iter++ = (*sx_iter++) / (*sy_iter++);
+					break;
+				case 3:
+					*seg_iter++ = std::max((*sx_iter++), (*sy_iter++));
+					break;
+				case 4:
+					*seg_iter++ = std::min((*sx_iter++), (*sy_iter++));
+					break;
+				}
 			}
 			set_segment(seg);
 		}
@@ -444,12 +424,11 @@ STIRImageData::scale(float s)
 }
 
 void
-STIRImageData::multiply(
-const DataContainer& a_x,
-const DataContainer& a_y)
-{
-	//STIRImageData& x = (STIRImageData&)a_x;
-	//STIRImageData& y = (STIRImageData&)a_y;
+STIRImageData::binary_op_(
+	const DataContainer& a_x,
+	const DataContainer& a_y, 
+	int job
+){
 	DYNAMIC_CAST(const STIRImageData, x, a_x);
 	DYNAMIC_CAST(const STIRImageData, y, a_y);
 #if defined(_MSC_VER) && _MSC_VER < 1900
@@ -466,36 +445,21 @@ const DataContainer& a_y)
 		iter_x = x.data().begin_all(), iter_y = y.data().begin_all();
 		iter != data().end_all() &&
 		iter_x != x.data().end_all() && iter_y != y.data().end_all();
-	iter++, iter_x++, iter_y++)
-		*iter = (*iter_x) * (*iter_y);
-}
-
-void
-STIRImageData::divide(
-const DataContainer& a_x,
-const DataContainer& a_y)
-{
-	//STIRImageData& x = (STIRImageData&)a_x;
-	//STIRImageData& y = (STIRImageData&)a_y;
-	DYNAMIC_CAST(const STIRImageData, x, a_x);
-	DYNAMIC_CAST(const STIRImageData, y, a_y);
-#if defined(_MSC_VER) && _MSC_VER < 1900
-	Image3DF::full_iterator iter;
-	Image3DF::const_full_iterator iter_x;
-	Image3DF::const_full_iterator iter_y;
-#else
-	typename Array<3, float>::full_iterator iter;
-	typename Array<3, float>::const_full_iterator iter_x;
-	typename Array<3, float>::const_full_iterator iter_y;
-#endif
-
-	for (iter = data().begin_all(),
-		iter_x = x.data().begin_all(), iter_y = y.data().begin_all();
-		iter != data().end_all() &&
-		iter_x != x.data().end_all() && iter_y != y.data().end_all();
-	iter++, iter_x++, iter_y++) {
-		*iter = (*iter_x) / (*iter_y);
-	}
+		iter++, iter_x++, iter_y++)
+		switch (job) {
+		case 1:
+			*iter = (*iter_x) * (*iter_y);
+			break;
+		case 2:
+			*iter = (*iter_x) / (*iter_y);
+			break;
+		case 3:
+			*iter = std::max(*iter_x, *iter_y);
+			break;
+		case 4:
+			*iter = std::min(*iter_x, *iter_y);
+			break;
+		}
 }
 
 int

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -43,11 +43,6 @@ import sirf.STIR_params as parms
 from sirf.config import SIRF_HAS_NiftyPET
 from sirf.config import SIRF_HAS_Parallelproj
 
-try:
-    input = raw_input
-except NameError:
-    pass
-
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 4:
     ABC = abc.ABC
 else:

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -30,6 +30,7 @@ except:
     HAVE_PYLAB = False
 import sys
 from numbers import Integral
+from deprecation import deprecated
 
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
      try_calling, assert_validity, \
@@ -1033,13 +1034,17 @@ class AcquisitionData(DataContainer):
             out = self.get_uniform_copy(value)
         return out
 
-    def get_info(self):
+    def parameter_info(self):
         """Returns the AcquisitionData's metadata as Python str."""
         handle = pystir.cSTIR_get_ProjDataInfo(self.handle)
         check_status(handle)
         info = pyiutil.charDataFromHandle(handle)
         pyiutil.deleteDataHandle(handle)
         return info
+
+    @deprecated(details="Please use parameter_info method instead")
+    def get_info(self):
+        return self.parameter_info()
 
     @property
     def shape(self):


### PR DESCRIPTION
Fixes https://github.com/SyneRBI/SIRF/issues/816.

@KrisThielemans -- Haven't compiled/tested but hopefully the logic should be clear here. The problem was that the python constructors for `NiftiImageData` and `NiftiImageData3D` but used the C++ `NiftiImageData` constructor, so there were no checks taking place.