### PR TITLE
Bugfix of accumulation of encoding spaces when getting ismrmrdheader

### DIFF
--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -112,10 +112,11 @@ namespace sirf {
 		{
 			if (!this->empty())
 				ISMRMRD::deserialize(data_.c_str(), header_);
+            have_header_ = true;
 		}
 		std::string data_;
         mutable ISMRMRD::IsmrmrdHeader header_;
-		bool have_header_;
+        mutable bool have_header_;
 	};
 
     class KSpaceSorting


### PR DESCRIPTION
The function `get_ISMRMRDHeader()` was `const`, but modified the mutable `header_` whenever it was called.
This caused the `deserialize` to write more and more encoding spaces into the header leading to unclear behaviour.

I fixed it by declaring the member `have_header_ ` also `mutable` and modify it s.t. only once the `deserialize()` is invoked.