### PR TITLE
[TRAVIS] drop xenial and python2, test focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 # Compilation dependencies
 addons:
  apt:
-  sources: &addons_apt_sources
+  sources:
   - ubuntu-toolchain-r-test
   packages: &addons_apt_packages
   - git-core
@@ -65,9 +65,8 @@ matrix:
    addons:
     apt:
      packages:
-      - *addons_apt_packages
-      - g++-8
-      - libinsighttoolkit4-dev
+     - *addons_apt_packages
+     - [g++-8, libinsighttoolkit4-dev]
    name: focal gcc8 -boost +itk +fftw3 +hdf5 +ace
    env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
  - os: linux
@@ -75,10 +74,8 @@ matrix:
    python: 3
    apt:
      packages:
-      - *addons_apt_packages
-      - g++-8
-      - libboost-all-dev
-      - libinsighttoolkit4-dev
+     - *addons_apt_packages
+     - [g++-8, libboost-all-dev, libinsighttoolkit4-dev]
    name: focal gcc8 +boost +itk +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
    env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
  - os: linux
@@ -86,9 +83,8 @@ matrix:
    addons:
     apt:
      packages:
-      - *addons_apt_packages
-      - g++-6
-      - libboost-all-dev
+     - *addons_apt_packages
+     - [g++-6, libboost-all-dev]
    name: bionic gcc6 +DEVEL -boost -hdf5 -fftw3 +ace +siemens_to_ismrmrd
    env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=ON -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  - os: linux
@@ -96,9 +92,8 @@ matrix:
    addons:
     apt:
      packages:
-      - *addons_apt_packages
-      - g++-7
-      - libinsighttoolkit4-dev
+     - *addons_apt_packages
+     - [g++-7, libinsighttoolkit4-dev]
    name: bionic gcc7 +DEVEL -boost -fftw3 -hdf5 -swig +ace
    env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=3
  ## osx g{cc,++} py{27,36}
@@ -127,9 +122,8 @@ matrix:
    addons:
     apt:
      packages:
-      - *addons_apt_packages
-      - g++-6
-      - libboost-all-dev
+     - *addons_apt_packages
+     - [g++-6, libboost-all-dev]
    name: bionic gcc6 +boost +itk +fftw3 +hdf5 +vtk
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_ITK=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  #- os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,10 +72,11 @@ matrix:
  - os: linux
    dist: focal
    python: 3
-   apt:
-     packages:
-     - *addons_apt_packages
-     - [g++-8, libboost-all-dev, libinsighttoolkit4-dev]
+   addons:
+     apt:
+       packages:
+       - *addons_apt_packages
+       - [g++-8, libboost-all-dev, libinsighttoolkit4-dev]
    name: focal gcc8 +boost +itk +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
    env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
  - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ env:
  - MAKEFLAGS="-j 2"
 matrix:
  include:
- # linux g{cc,++}-{6,7,9}
+ # linux g{cc,++}-{6,7,8}
  - os: linux
    dist: focal
    python: 3
@@ -68,16 +68,20 @@ matrix:
     apt:
      packages:
       - *addons_apt_packages
+      - gcc-8
+      - g++-8
    name: focal -boost +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
  - os: linux
    dist: focal
    python: 3
    apt:
      packages:
       - *addons_apt_packages
+      - gcc-8
+      - g++-8
    name: focal -boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
  - os: linux
    python: 3
    addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
   packages: &addons_apt_packages
   - git-core
   - build-essential
-  - libboost-all-dev
   - libhdf5-serial-dev
   - libfftw3-dev
   - python3-dev
@@ -40,7 +39,6 @@ addons:
   - libxslt-dev
   - libace-dev
   # - root-system-bin
-  - libinsighttoolkit4-dev
 
 # Environment variables
 # Note: On trusty we need to build Armadillo and boost ourselves (the system versions are too old)
@@ -68,9 +66,9 @@ matrix:
     apt:
      packages:
       - *addons_apt_packages
-      - gcc-8
       - g++-8
-   name: focal -boost +fftw3 +hdf5 +ace
+      - libinsighttoolkit4-dev
+   name: focal gcc8 -boost +itk +fftw3 +hdf5 +ace
    env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
  - os: linux
    dist: focal
@@ -78,10 +76,11 @@ matrix:
    apt:
      packages:
       - *addons_apt_packages
-      - gcc-8
       - g++-8
-   name: focal -boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
+      - libboost-all-dev
+      - libinsighttoolkit4-dev
+   name: focal gcc8 +boost +itk +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-8 CXX=g++-8" PYMVER=3
  - os: linux
    python: 3
    addons:
@@ -89,6 +88,7 @@ matrix:
      packages:
       - *addons_apt_packages
       - g++-6
+      - libboost-all-dev
    name: bionic gcc6 +DEVEL -boost -hdf5 -fftw3 +ace +siemens_to_ismrmrd
    env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=ON -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  - os: linux
@@ -98,6 +98,7 @@ matrix:
      packages:
       - *addons_apt_packages
       - g++-7
+      - libinsighttoolkit4-dev
    name: bionic gcc7 +DEVEL -boost -fftw3 -hdf5 -swig +ace
    env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=3
  ## osx g{cc,++} py{27,36}
@@ -128,8 +129,9 @@ matrix:
      packages:
       - *addons_apt_packages
       - g++-6
-   name: bionic gcc6 -boost +itk +fftw3 +hdf5 +vtk
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_ITK=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
+      - libboost-all-dev
+   name: bionic gcc6 +boost +itk +fftw3 +hdf5 +vtk
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_ITK=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  #- os: osx
  #  python: 3
  #  # +boost +itk -hdf5 +swig +vtk

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,15 @@ sudo: false
 # Compilation dependencies
 addons:
  apt:
-  sources:
+  sources: &addons_apt_sources
   - ubuntu-toolchain-r-test
-  packages:
+  packages: &addons_apt_packages
   - git-core
   - build-essential
-  - g++-6
-  - g++-7
   - libboost-all-dev
   - libhdf5-serial-dev
   - libfftw3-dev
-  - python-dev
   - python3-dev
-  - python-tk
   - python3-tk
   - libopenblas-dev
   - libatlas-base-dev
@@ -64,25 +60,42 @@ env:
  - MAKEFLAGS="-j 2"
 matrix:
  include:
- # linux g{cc,++}-6 py{27,3}
+ # linux g{cc,++}-{6,7,9}
  - os: linux
-   dist: xenial
+   dist: focal
    python: 3
-   # -boost +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
+   addons:
+    apt:
+     packages:
+      - *addons_apt_packages
+   name: focal -boost +fftw3 +hdf5 +ace
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: linux
-   dist: xenial
-   python: 2.7
-   # -boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
+   dist: focal
+   python: 3
+   apt:
+     packages:
+      - *addons_apt_packages
+   name: focal -boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: linux
    python: 3
-   # +DEVEL -boost -hdf5 -fftw3 +ace +siemens_to_ismrmrd
+   addons:
+    apt:
+     packages:
+      - *addons_apt_packages
+      - g++-6
+   name: bionic gcc6 +DEVEL -boost -hdf5 -fftw3 +ace +siemens_to_ismrmrd
    env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=ON -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  - os: linux
-   python: 2.7
-   # +DEVEL -boost -fftw3 -hdf5 -swig +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
+   python: 3
+   addons:
+    apt:
+     packages:
+      - *addons_apt_packages
+      - g++-7
+   name: bionic gcc7 +DEVEL -boost -fftw3 -hdf5 -swig +ace
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK:BOOL=ON -DUSE_SYSTEM_ITK:BOOL=ON -DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-7 CXX=g++-7" PYMVER=3
  ## osx g{cc,++} py{27,36}
  #- os: osx
  #  osx_image: xcode11.2
@@ -106,7 +119,12 @@ matrix:
  #  env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON -DUSE_ITK=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: linux
    python: 3
-   # -boost +itk +fftw3 +hdf5 +vtk
+   addons:
+    apt:
+     packages:
+      - *addons_apt_packages
+      - g++-6
+   name: bionic gcc6 -boost +itk +fftw3 +hdf5 +vtk
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_ITK=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_VTK=ON -DUSE_SYSTEM_VTK=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  #- os: osx
  #  python: 3
@@ -165,14 +183,15 @@ before_install:
      )
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
      PY_EXE=python$PYMVER
-     curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz
-     tar xzf cmake.tgz && rm cmake.tgz
-     ln -s cmake-*x86_64 cmake
-     export PATH="$PWD/cmake/bin:$PATH"
+     #curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz
+     #tar xzf cmake.tgz && rm cmake.tgz
+     #ln -s cmake-*x86_64 cmake
+     #export PATH="$PWD/cmake/bin:$PATH"
      if [[ $EXTRA_BUILD_FLAGS == *"-DUSE_VTK=ON"* ]] && [[ $EXTRA_BUILD_FLAGS == *"-DUSE_SYSTEM_VTK=ON"* ]]; then
        sudo apt install libvtk7-dev
      fi
    fi
+- $PY_EXE --version
 # get pip
 - curl -0 https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 - $PY_EXE get-pip.py --user


### PR DESCRIPTION
- Ubuntu 16.04 has more and more trouble, including with pip installation.
- python2 is no longer supported by many packages
- we really need to test with more recent Ubuntu, so using 20.04 LTS (focal)

In addition, some improvements:
- install some apt packages only on certain jobs
- give jobs names

As focal's CMake is more recent than 3.13, it would be dangerous to use the older version.
Therefore just relying on the default CMake (which is 3.10 on bionic so should be fine)

Fixes #854 