### PR TITLE
Bug in cSTIR_setOSMAPOSLParameter when setting set_minimum_relative_change

### DIFF
--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -696,9 +696,9 @@ sirf::cSTIR_setOSMAPOSLParameter
 		objectFromHandle<OSMAPOSLReconstruction<Image3DF> >(hp);
     if (boost::iequals(name, "set_maximum_relative_change"))
             recon.set_maximum_relative_change(dataFromHandle<double>((void*)hv));
-    if (boost::iequals(name, "set_minimum_relative_change"))
+    else if (boost::iequals(name, "set_minimum_relative_change"))
             recon.set_minimum_relative_change(dataFromHandle<double>((void*)hv));
-	if (boost::iequals(name, "MAP_model"))
+	else if (boost::iequals(name, "MAP_model"))
 		recon.set_MAP_model(charDataFromDataHandle(hv));
 	else
 		return parameterNotFound(name, __FILE__, __LINE__);


### PR DESCRIPTION
Prevents `parameterNotFound` error when setting minimum or maximum relative change for OSMAPOSL.

Fixes #860 