### PR TITLE
Fix listmode processing after STIR update

### DIFF
--- a/src/xSTIR/cSTIR/stir_x.cpp
+++ b/src/xSTIR/cSTIR/stir_x.cpp
@@ -325,13 +325,11 @@ ListmodeToSinograms::compute_singles_()
 void
 ListmodeToSinograms::estimate_randoms_()
 {
-	PETAcquisitionDataInFile acq_temp(template_proj_data_name.c_str());
-	shared_ptr<ProjData> template_projdata_ptr = acq_temp.data();
 	std::string filename = output_filename_prefix + "_randoms" + "_f1g1d0b0.hs";
 	shared_ptr<ExamInfo> exam_info_sptr(new ExamInfo(lm_data_ptr->get_exam_info()));
 	const ProjDataInfo& proj_data_info = *lm_data_ptr->get_proj_data_info_sptr();
 	exam_info_sptr->set_time_frame_definitions(frame_defs);
-	shared_ptr<ProjDataInfo> temp_proj_data_info_sptr(acq_temp.get_proj_data_info_sptr()->clone());
+	shared_ptr<ProjDataInfo> temp_proj_data_info_sptr(template_proj_data_info_ptr->clone());
 	const float h = proj_data_info.get_bed_position_horizontal();
 	const float v = proj_data_info.get_bed_position_vertical();
 	temp_proj_data_info_sptr->set_bed_position_horizontal(h);
@@ -340,10 +338,9 @@ ListmodeToSinograms::estimate_randoms_()
 	ProjData& proj_data = *randoms_sptr->data();
 
 	const int num_rings =
-		template_projdata_ptr->get_proj_data_info_sptr()->get_scanner_ptr()->
-		get_num_rings();
+                temp_proj_data_info_sptr->get_scanner_ptr()->get_num_rings();
 	const int num_detectors_per_ring =
-		template_projdata_ptr->get_proj_data_info_sptr()->get_scanner_ptr()->
+		temp_proj_data_info_sptr->get_scanner_ptr()->
 		get_num_detectors_per_ring();
 	DetectorEfficiencies& efficiencies = *det_eff_sptr;
 

--- a/src/xSTIR/cSTIR/tests/CMakeLists.txt
+++ b/src/xSTIR/cSTIR/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 #========================================================================
 # Author: Kris Thielemans
-# Copyright 2016, 2018 University College London
+# Copyright 2016, 2018, 2021 University College London
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -17,8 +17,14 @@
 #=========================================================================
 
 # Create an executable
-  add_executable(cstir_tests test1.cpp test2.cpp test4.cpp main.cpp ${STIR_REGISTRIES})
+  add_executable(cstir_tests test1.cpp test2.cpp main.cpp ${STIR_REGISTRIES})
   target_link_libraries(cstir_tests csirf cstir ${STIR_LIBRARIES})
   INSTALL(TARGETS cstir_tests DESTINATION bin)
 
-ADD_TEST(NAME PET_TESTS_CPLUSPLUS COMMAND cstir_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_executable(cstir_test4  test4.cpp run_test4.cpp ${STIR_REGISTRIES})
+  target_link_libraries(cstir_test4 csirf cstir ${STIR_LIBRARIES})
+  INSTALL(TARGETS cstir_tests DESTINATION bin)
+
+ADD_TEST(NAME PET_TESTS_CPLUSPLUS_1 COMMAND cstir_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+ADD_TEST(NAME PET_TESTS_CPLUSPLUS_4 COMMAND cstir_test4 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/xSTIR/cSTIR/tests/run_test4.cpp
+++ b/src/xSTIR/cSTIR/tests/run_test4.cpp
@@ -1,7 +1,7 @@
 /*
 SyneRBI Synergistic Image Reconstruction Framework (SIRF)
 Copyright 2018 - 2020 Rutherford Appleton Laboratory STFC
-Copyright 2018 - 2020 University College London
+Copyright 2018 - 2021 University College London
 
 This is software developed for the Collaborative Computational
 Project in Synergistic Reconstruction for Biomedical Imaging (formerly CCP PETMR)
@@ -24,20 +24,19 @@ limitations under the License.
 \ingroup STIR Tests
 
 \author Evgueni Ovtchinnikov
-\author Richard Brown
+\author Kris Thielemans
 \author SyneRBI
 */
 
 #include <iostream>
+#include <cstdlib>
 
-int test1();
-int test2();
+int test4();
 
 int main()
 {
-	int failed = 0;
-	failed += test1();
-	failed += test2();
+	const int failed = test4();
 	std::cout << failed << " tests failed\n";
-	return failed;
+        
+	return failed==0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
https://github.com/UCL/STIR/pull/828 broke SIRF, but allows working without filenames. Therefore, added `set_template(const PETAcquisitionData&`.

Addresses C++ side of #173

Also separate a ctest