### PR TITLE
adjust macro for setting of C++ standard

### DIFF
--- a/cmake/SetC++Version.cmake
+++ b/cmake/SetC++Version.cmake
@@ -1,16 +1,29 @@
+#========================================================================
+# Author: Kris Thielemans
+# Copyright 2020-2021 University College London
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
 # A macro to set the C++ version
-# Based on https://stackoverflow.com/questions/10851247/how-to-activate-c-11-in-cmake
+# If CMAKE_CXX_STANDARD is already set to a more recent version, keep that.
 macro(UseCXX VERSION)
-  if (CMAKE_VERSION VERSION_LESS "3.1")
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      # Strictly speaking, this enables C++11 (or whatever) with GNU extensions.
-      # However, this is what recent CMake does with CMAKE_CXX_STANDARD,
-      # so we'll do the same.
-      set (CMAKE_CXX_FLAGS "-std=gnu++${VERSION} ${CMAKE_CXX_FLAGS}")
-    else()
-      set (CMAKE_CXX_FLAGS "-std=c++${VERSION} ${CMAKE_CXX_FLAGS}")
-    endif ()
-  else ()
+  if (NOT DEFINED CMAKE_CXX_STANDARD)
     set (CMAKE_CXX_STANDARD ${VERSION})
+  else()
+    if ((CMAKE_CXX_STANDARD EQUAL 98) OR (CMAKE_CXX_STANDARD LESS VERSION))
+      message(FATAL_ERROR "CXX_STANDARD needs to be at least ${VERSION}")
+    endif()
   endif ()
 endmacro(UseCXX)


### PR DESCRIPTION
- keep more recent C++ version if the user set it by hand
- remove support for old CMake versions (as we require 3.9 anyway)

Fixes #503