### PR TITLE
Find SIRF_PATH based on py install dir [ci skip]

### DIFF
--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -55,9 +55,32 @@ def examples_data_path(data_type):
         return os.path.join(SIRF_INSTALL_PATH , data_path)
     elif SIRF_PATH is not None:
         return os.path.join(SIRF_PATH, 'data', 'examples', data_type)
-    else:
-        errorMsg = 'You need to set the SIRF_DATA_PATH or SIRF_INSTALL_PATH environment variable to allow finding the raw data.'
-        raise ValueError(errorMsg)
+
+    # one final effort
+    try:
+        py_root = sirf.__file__
+        try:
+            # is install dir like $SIRF_PATH/lib/python3.8/site-packages?
+            lib_idx = py_root.split(os.sep).index('lib')
+        except ValueError:
+            # is install dir like $SIRF_PATH/python?
+            lib_idx = py_root.split(os.sep).index('python')
+        potential_install_loc = os.path.join(os.sep, *py_root.split(os.sep)[:lib_idx])
+        sirf_ver_folder = 'SIRF-{}.{}'.format(
+            sirf.__version_major__, sirf.__version_minor__)
+        potential_sirf_data_path = os.path.join(
+            potential_install_loc, 'share', sirf_ver_folder, 'data',
+            'examples', data_type)
+        print(potential_sirf_data_path)
+        if os.path.exists(potential_sirf_data_path):
+            return potential_sirf_data_path
+    except Exception:
+        pass
+
+    errorMsg = \
+        'You need to set the SIRF_DATA_PATH or SIRF_INSTALL_PATH ' \
+        'environment variable to allow finding the raw data.'
+    raise ValueError(errorMsg)
 
 def existing_filepath(data_path, file_name):
     '''

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -60,12 +60,13 @@ def examples_data_path(data_type):
     try:
         py_root = sirf.__file__
         try:
-            # is install dir like $SIRF_PATH/lib/python3.8/site-packages?
+            # is install dir like $SIRF_INSTALL_PATH/lib/python?.?/site-packages?
             lib_idx = py_root.split(os.sep).index('lib')
         except ValueError:
-            # is install dir like $SIRF_PATH/python?
+            # is install dir like $SIRF_INSTALL_PATH/python?
             lib_idx = py_root.split(os.sep).index('python')
-        potential_install_loc = os.path.join(os.sep, *py_root.split(os.sep)[:lib_idx])
+        potential_install_loc = os.path.abspath(
+            os.path.join(os.sep, *py_root.split(os.sep)[:lib_idx]))
         sirf_ver_folder = 'SIRF-{}.{}'.format(
             sirf.__version_major__, sirf.__version_minor__)
         potential_sirf_data_path = os.path.join(

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -58,24 +58,32 @@ def examples_data_path(data_type):
 
     # one final effort
     try:
-        py_root = sirf.__file__
+        # Try find <SIRF_INSTALL_PATH>/share/data/examples
+        py_root = os.path.abspath(sirf.__file__)
         try:
-            # is install dir like $SIRF_INSTALL_PATH/lib/python?.?/site-packages?
+            # is install dir like <SIRF_INSTALL_PATH>/lib/python?.?/site-packages?
             lib_idx = py_root.split(os.sep).index('lib')
         except ValueError:
-            # is install dir like $SIRF_INSTALL_PATH/python?
+            # is install dir like <SIRF_INSTALL_PATH>/python? (SuperBuild)
             lib_idx = py_root.split(os.sep).index('python')
-        potential_install_loc = os.path.abspath(
-            os.path.join(os.sep, *py_root.split(os.sep)[:lib_idx]))
+        # on Unix, first element of split is empty
+        # On Windows, first element of split is Drive
+        # Split out this first element and get SIRF_INSTALL_PATH candidate
+        maybe_drive, *path_to_sirf = py_root.split(os.sep)[:lib_idx]
+        potential_install_loc = \
+            maybe_drive + os.path.join(os.sep, *path_to_sirf)
+        # Now data_dir might be:
+        # <SIRF_INSTALL_PATH>/share/SIRF-<major>.<minor>/data/examples
         sirf_ver_folder = 'SIRF-{}.{}'.format(
             sirf.__version_major__, sirf.__version_minor__)
         potential_sirf_data_path = os.path.join(
             potential_install_loc, 'share', sirf_ver_folder, 'data',
             'examples', data_type)
-        print(potential_sirf_data_path)
+        # if it exists, assume that's it
         if os.path.exists(potential_sirf_data_path):
             return potential_sirf_data_path
-    except Exception:
+    except Exception as e:
+        # didn't work
         pass
 
     errorMsg = \


### PR DESCRIPTION
In my installation I don't usually bother with $SIRF_PATH. I think we could try and guess it from the Python directory?

This works for me locally.