### PR TITLE
Added acquisition data without view mashing to data submodule, fixes #907

### DIFF
--- a/examples/Python/PET/fbp2d_reconstruction.py
+++ b/examples/Python/PET/fbp2d_reconstruction.py
@@ -5,7 +5,7 @@ Usage:
 
 Options:
   -d <file>, --file=<file>    raw data file
-                              [default: my_forward_projection.hs]
+                              [default: simulated_data.hs]
   -p <path>, --path=<path>    path to data files, defaults to data/examples/PET
                               subfolder of SIRF root folder
   -e <engn>, --engine=<engn>  reconstruction engine [default: STIR]


### PR DESCRIPTION
Script `fbp2d_reconstruction.py` fails on data with view mashing. This PR adds acquisition data without view mashing to `data` submodule and makes it default raw input data for `fbp2d_reconstruction.py`.