### PR TITLE
Constructor for MR image data from MR acquisition data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   - Encoding classes perform the Fourier transformations instead of the MRAcquisitionModel
   - Golden-angle radial phase encoding (RPE) trajectory is supported.
   - CoilSensitivitiesVector class now has forward and backward method using the encoding classes getting rid of the duplicate FFT code used to compute coil sensitivities from MRAcquisitionData.
+  - added constructor for GadgetronImagesVector from MRAcquisitionData. This allows setting up an MR acquisition model without having to perform a reconstruction before. 
 
 * Build system
   - fix bug with older CMake (pre-3.12?) that the Python interface was not built

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -913,6 +913,20 @@ cGT_readImages(const char* file)
 }
 
 extern "C"
+void *
+cGT_ImageFromAcquisitiondata(void* ptr_acqs)
+{
+	try {
+		CAST_PTR(DataHandle, h_acqs, ptr_acqs);
+		MRAcquisitionData& acqs =
+			objectFromHandle<MRAcquisitionData>(h_acqs);
+		auto sptr_iv = std::make_shared<GadgetronImagesVector>(acqs);
+		return newObjectHandle<GadgetronImageData>(sptr_iv);
+	}
+	CATCH;
+}
+
+extern "C"
 void*
 cGT_processImages(void* ptr_proc, void* ptr_input)
 {

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -2,7 +2,7 @@
 SyneRBI Synergistic Image Reconstruction Framework (SIRF)
 Copyright 2015 - 2020 Rutherford Appleton Laboratory STFC
 Copyright 2019 - 2020 University College London
-Copyright 2020 Physikalisch-Technische Bundesanstalt (PTB)
+Copyright 2020 - 2021 Physikalisch-Technische Bundesanstalt (PTB)
 
 This is software developed for the Collaborative Computational
 Project in Synergistic Reconstruction for Biomedical Imaging (formerly CCP PETMR)

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1257,6 +1257,9 @@ GadgetronImagesVector::GadgetronImagesVector(const MRAcquisitionData& ad, const 
         subset.get_acquisition(0, acq);
         match_img_header_to_acquisition(img, acq);
 
+        for(auto it=img.begin(); it!=img.end(); ++it)
+            *it = complex_float_t(0.f,0.f);
+
         this->append(img);
     }
 }    

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
@@ -86,6 +86,8 @@ extern "C" {
 	void* cGT_reconstructImages(void* ptr_recon, void* ptr_input);
 	void* cGT_reconstructedImages(void* ptr_recon);
     void* cGT_readImages(const char* file);
+	void* cGT_ImageFromAcquisitiondata(void* ptr_acqs);
+
 	void* cGT_processImages(void* ptr_proc, void* ptr_input);
 	void* cGT_selectImages
 		(void* ptr_input, const char* attr, const char* target);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -881,6 +881,17 @@ namespace sirf {
 
 		GadgetronImagesVector() : images_()
 		{}
+
+		/*!
+		\ingroup MR
+		\brief Constructor for images from MR Acquisition data.
+
+		The images are generated with the dimensions given in the recon-space of the 
+		MRAcquisitionData's ISMRMRD header information.
+		The geometry information and header of the individual images are populated
+		based on all consistent subsets of acquisitions in the MRAcquisition object.
+		The images can also be created coil-resolved.
+		*/
 		GadgetronImagesVector(const MRAcquisitionData& ad, const bool coil_resolved=false);
         GadgetronImagesVector(const GadgetronImagesVector& images);
 		GadgetronImagesVector(GadgetronImagesVector& images, const char* attr,

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -1074,8 +1074,8 @@ namespace sirf {
     public:
 
         CoilSensitivitiesVector() : GadgetronImagesVector(){}
-		CoilSensitivitiesVector(MRAcquisitionData& ad, const bool coil_resolved=true) :
-			GadgetronImagesVector(ad, coil_resolved){}
+		CoilSensitivitiesVector(MRAcquisitionData& ad) :
+			GadgetronImagesVector(ad, true){}
         CoilSensitivitiesVector(const char * file)
         {
             throw std::runtime_error("This has not been implemented yet.");

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -322,7 +322,7 @@ namespace sirf {
         */
         std::vector<KSpaceSubset::SetType > get_kspace_order() const;
 
-        //! Function to get the all KSpaceSorting of the MRAcquisitionData
+        //! Function to get the all KSpaceSubset's of the MRAcquisitionData
         std::vector<KSpaceSubset> get_kspace_sorting() const { return this->sorting_; }
 
         //! Function to go through Acquisitions and assign them to their k-space dimension
@@ -876,7 +876,7 @@ namespace sirf {
 
 		GadgetronImagesVector() : images_()
 		{}
-		GadgetronImagesVector(const MRAcquisitionData& ad);
+		GadgetronImagesVector(const MRAcquisitionData& ad, const bool coil_resolved=false);
         GadgetronImagesVector(const GadgetronImagesVector& images);
 		GadgetronImagesVector(GadgetronImagesVector& images, const char* attr,
 			const char* target);
@@ -1058,6 +1058,8 @@ namespace sirf {
     public:
 
         CoilSensitivitiesVector() : GadgetronImagesVector(){}
+		CoilSensitivitiesVector(MRAcquisitionData& ad, const bool coil_resolved=true) :
+			GadgetronImagesVector(ad, coil_resolved){}
         CoilSensitivitiesVector(const char * file)
         {
             throw std::runtime_error("This has not been implemented yet.");
@@ -1100,6 +1102,8 @@ namespace sirf {
         float max_(int nx, int ny, int nz, float* u);
 
     };
+
+void match_img_header_to_acquisition(CFImage& img, const ISMRMRD::Acquisition& acq);
 
 }
 

--- a/src/xGadgetron/cGadgetron/tests/mrtests.cpp
+++ b/src/xGadgetron/cGadgetron/tests/mrtests.cpp
@@ -121,6 +121,19 @@ bool test_ISMRMRDImageData_from_MRAcquisitionData(MRAcquisitionData& av)
         MatrixSize rawdata_recon_matrix = rec_space.matrixSize;
         FieldOfView_mm rawdata_recon_FOV = rec_space.fieldOfView_mm;
 
+        for(int i=0; i<iv.number(); ++i)
+        {
+            CFImage* const ptr_img = (CFImage*)(iv.sptr_image_wrap(i)->ptr_image());            
+
+            test_successful *= (ptr_img->getMatrixSizeX() == rawdata_recon_matrix.x);
+            test_successful *= (ptr_img->getMatrixSizeY() == rawdata_recon_matrix.y);
+            test_successful *= (ptr_img->getMatrixSizeZ() == rawdata_recon_matrix.z);
+
+        	test_successful *= (ptr_img->getFieldOfViewX() == rawdata_recon_FOV.x);
+            test_successful *= (ptr_img->getFieldOfViewY() == rawdata_recon_FOV.y);
+            test_successful *= (ptr_img->getFieldOfViewZ() == rawdata_recon_FOV.z);
+        }
+
         if(test_successful)
             return test_successful;
         else{
@@ -591,7 +604,7 @@ int main ( int argc, char* argv[])
         ok *= test_get_kspace_order(av);
         ok *= test_get_subset(av);
 
-        // ok *= test_ISMRMRDImageData_from_MRAcquisitionData(av);
+        ok *= test_ISMRMRDImageData_from_MRAcquisitionData(av);
 
         ok *= test_CoilSensitivitiesVector_calculate(av);
         ok *= test_CoilSensitivitiesVector_get_csm_as_cfimage(av);

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -252,6 +252,14 @@ class ImageData(SIRF.ImageData):
             pyiutil.deleteDataHandle(self.handle)
         self.handle = pygadgetron.cGT_readImages(file)
         check_status(self.handle)
+
+    def from_acquisition_data(self, ad):
+        assert isinstance(ad, AcquisitionData), "Please pass a AcquisitionData object"
+        if self.handle is not None:
+            pyiutil.deleteDataHandle(self.handle)
+        self.handle = pygadgetron.cGT_ImageFromAcquisitiondata(ad.handle)
+        check_status(self.handle)
+
     def data_type(self, im_num):
         '''
         Returns the data type for a specified image (see 8 data types above).

--- a/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
+++ b/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
@@ -27,12 +27,30 @@ def test_main(rec=False, verb=False, throw=True):
     data_path = examples_data_path('MR')
     
     rawdata = AcquisitionData(data_path + '/simulated_MR_2D_cartesian.h5')
-    test_img_dimensions = (2, 256, 256)
+    rawdata = preprocess_acquisition_data(rawdata)
+    rawdata.sort()
+    
+    
 
     imgdata = ImageData()
     imgdata.from_acquisition_data(rawdata)
     
-    test_successful = imgdata.dimensions() == test_img_dimensions
+        
+    acq_model = AcquisitionModel()
+    acq_model.set_up(rawdata, imgdata)
+
+    csms = CoilSensitivityData()
+    csms.calculate(rawdata)
+    acq_model.set_coil_sensitivity_maps(csms)
+
+    bwd_img = acq_model.backward(rawdata)
+
+    print("The empty images have norm: {}".format(imgdata.norm()))
+    print("The backprojected rawdata have norm: {}".format(bwd_img.norm()))
+    test_successful = imgdata.norm() != bwd_img.norm()
+
+    test_img_dimensions = (2, 256, 256)
+    test_successful *= imgdata.dimensions() == test_img_dimensions
 
     return test_successful, 1
 

--- a/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
+++ b/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-"""sirf.Gadgetron Test set 1.
+"""sirf.Gadgetron test.
 v{version}
 
-Fully sampled data tests
+Constructor of MR image data from MR acquisition data
 
 Usage:
   test_imagedata_constructor [--help | options]
@@ -14,7 +14,7 @@ Options:
 
 {licence}
 """
-# Created on Tue Nov 21 10:17:28 2017
+
 from sirf.Gadgetron import *
 from sirf.Utilities import runner, RE_PYEXT, __license__
 __version__ = "0.2.3"

--- a/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
+++ b/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""sirf.Gadgetron Test set 1.
+v{version}
+
+Fully sampled data tests
+
+Usage:
+  test_imagedata_constructor [--help | options]
+
+Options:
+  -r, --record   record the measurements rather than check them
+  -v, --verbose  report each test status
+{author}
+
+{licence}
+"""
+# Created on Tue Nov 21 10:17:28 2017
+from sirf.Gadgetron import *
+from sirf.Utilities import runner, RE_PYEXT, __license__
+__version__ = "0.2.3"
+__author__ = "Johannes Mayer"
+
+
+def test_main(rec=False, verb=False, throw=True):
+    print("Running the constructor test")
+
+    data_path = examples_data_path('MR')
+    AcquisitionData.set_storage_scheme('memory')
+    
+    rawdata = AcquisitionData(data_path + '/simulated_MR_2D_cartesian.h5')
+    
+    imgdata = ImageData()
+    imgdata.from_acquisition_data(rawdata)
+
+    test_successful = (imgdata.number() == rawdata.number())
+
+    return test_successful, 1
+
+
+if __name__ == "__main__":
+    runner(test_main, __doc__, __version__, __author__)

--- a/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
+++ b/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
@@ -22,17 +22,17 @@ __author__ = "Johannes Mayer"
 
 
 def test_main(rec=False, verb=False, throw=True):
-    print("Running the constructor test")
 
+    print("Running the ImageData from AcquisitionData constructor test")
     data_path = examples_data_path('MR')
-    AcquisitionData.set_storage_scheme('memory')
     
     rawdata = AcquisitionData(data_path + '/simulated_MR_2D_cartesian.h5')
-    
+    test_img_dimensions = (2, 256, 256)
+
     imgdata = ImageData()
     imgdata.from_acquisition_data(rawdata)
-
-    test_successful = (imgdata.number() == rawdata.number())
+    
+    test_successful = imgdata.dimensions() == test_img_dimensions
 
     return test_successful, 1
 


### PR DESCRIPTION
Fixes #933

The following operation is performed:
* for each consistent subsets of k-space a `CFImage` is created and appended. 
* the header is populated based on the first acquisition in each subset

While there are fields in the ISMRMRD XML header of the whole rawdata file comprising all acquisitions, the image headers are populated from the `Acquisition` object to include the geometry information that can vary between different subsets of k-space, for example for different 2D slices.
It is assumed that the `Acquisition` objects in each subset contain the same header information.