### PR TITLE
remove use of PYTHON_FOUND

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
   - CoilSensitivitiesVector class now has forward and backward method using the encoding classes getting rid of the duplicate FFT code used to compute coil sensitivities from MRAcquisitionData.
 
 * Build system
-  - fix bug with CMake 3.12 or more recent that the Python interface was not built
+  - fix bug with older CMake (pre-3.12?) that the Python interface was not built
   [#939](https://github.com/SyneRBI/SIRF/issues/939).
 
 ## v3.0.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
   - Golden-angle radial phase encoding (RPE) trajectory is supported.
   - CoilSensitivitiesVector class now has forward and backward method using the encoding classes getting rid of the duplicate FFT code used to compute coil sensitivities from MRAcquisitionData.
 
+* Build system
+  - fix bug with CMake 3.12 or more recent that the Python interface was not built
+  [#939](https://github.com/SyneRBI/SIRF/issues/939).
 
 ## v3.0.0
 ### Backwards incompatible changes

--- a/src/Registration/CMakeLists.txt
+++ b/src/Registration/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 add_subdirectory(NiftyMoMo)
 add_subdirectory(cReg)
-if (PYTHON_FOUND AND BUILD_PYTHON)
+if (BUILD_PYTHON)
   add_subdirectory(pReg)
 endif()
 add_subdirectory(mReg)

--- a/src/Synergistic/CMakeLists.txt
+++ b/src/Synergistic/CMakeLists.txt
@@ -34,7 +34,7 @@ ENDFOREACH(elem ${SYN_executables})
 
 add_subdirectory(cSyn)
 add_subdirectory(mSyn)
-if (PYTHON_FOUND AND BUILD_PYTHON)
+if (BUILD_PYTHON)
   add_subdirectory(pSyn)
 endif()
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -45,7 +45,7 @@ else()
 endif()
 INSTALL(TARGETS csirf DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
-if (BUILD_PYTHON AND PYTHON_FOUND)
+if (BUILD_PYTHON)
   if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13") 
     # policy introduced in CMake 3.13
     cmake_policy(SET CMP0078 OLD)

--- a/src/iUtilities/CMakeLists.txt
+++ b/src/iUtilities/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(iutilities PUBLIC
 
 target_include_directories(iutilities PUBLIC ${Boost_INCLUDE_DIRS})
 
-if(BUILD_PYTHON AND PYTHON_FOUND)
+if(BUILD_PYTHON)
   if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13") 
     # policy introduced in CMake 3.13
     cmake_policy(SET CMP0078 OLD)

--- a/src/xGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/CMakeLists.txt
@@ -32,7 +32,7 @@ if (SIRF_INSTALL_DEPENDENCIES AND WIN32)
 endif()
 
 add_subdirectory(cGadgetron)
-if (PYTHON_FOUND AND BUILD_PYTHON)
+if (BUILD_PYTHON)
   add_subdirectory(pGadgetron)
 endif()
 add_subdirectory(mGadgetron)

--- a/src/xSTIR/CMakeLists.txt
+++ b/src/xSTIR/CMakeLists.txt
@@ -17,7 +17,7 @@
 #=========================================================================
 
 add_subdirectory(cSTIR)
-if (PYTHON_FOUND AND BUILD_PYTHON)
+if (BUILD_PYTHON)
   add_subdirectory(pSTIR)
 endif()
 add_subdirectory(mSTIR)


### PR DESCRIPTION
This variable no longer exists when using `find(Python ...)`, i.e. with CMake 3.12 or more recent.

Fixes #939