### PR TITLE
Auto sort by time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   - Golden-angle radial phase encoding (RPE) trajectory is supported.
   - CoilSensitivitiesVector class now has forward and backward method using the encoding classes getting rid of the duplicate FFT code used to compute coil sensitivities from MRAcquisitionData.
   - added constructor for GadgetronImagesVector from MRAcquisitionData. This allows setting up an MR acquisition model without having to perform a reconstruction before. 
+  - automatically calls sort_by_time() in MRAcquisitionData::read() and AcquisitionProcessor::get_output() to take away responsibility from the user when to call sort()
 
 * Build system
   - fix bug with older CMake (pre-3.12?) that the Python interface was not built

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -522,6 +522,7 @@ cGT_processAcquisitions(void* ptr_proc, void* ptr_input)
 			objectFromHandle<MRAcquisitionData>(h_input);
 		proc.process(input);
 		shared_ptr<MRAcquisitionData> sptr_ac = proc.get_output();
+		sptr_ac.sort_by_time();
 		return newObjectHandle<MRAcquisitionData>(sptr_ac);
 	}
 	CATCH;

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -522,7 +522,6 @@ cGT_processAcquisitions(void* ptr_proc, void* ptr_input)
 			objectFromHandle<MRAcquisitionData>(h_input);
 		proc.process(input);
 		shared_ptr<MRAcquisitionData> sptr_ac = proc.get_output();
-		sptr_ac.sort_by_time();
 		return newObjectHandle<MRAcquisitionData>(sptr_ac);
 	}
 	CATCH;

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -119,7 +119,7 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 			else
 				this->append_acquisition( acq );
 		}
-        this->organise_kspace();
+        this->sort_by_time();
 		if( verbose )
 			std::cout<< "\nFinished reading acquisitions from " << filename_ismrmrd_with_ext << std::endl;
 	}

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -215,7 +215,9 @@ namespace sirf {
 		void process(MRAcquisitionData& acquisitions);
 		gadgetron::shared_ptr<MRAcquisitionData> get_output()
 		{
-			sptr_acqs_->sort_by_time();
+			if(!sptr_acqs_->sorted())
+			 	sptr_acqs_->sort_by_time();
+
 			return sptr_acqs_;
 		}
 

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -215,6 +215,7 @@ namespace sirf {
 		void process(MRAcquisitionData& acquisitions);
 		gadgetron::shared_ptr<MRAcquisitionData> get_output()
 		{
+			sptr_acqs_->sort_by_time();
 			return sptr_acqs_;
 		}
 


### PR DESCRIPTION
Fixes #949.

Both the `MRAcquisitionData::read()` function and the `AcquisitionsProcessor::get_output()` return sorted containers now.
`MRAcquisitionModel` and `CoilsensitivityData` basically always need sorted data so this takes away the responsibility from the user to call `sort()` in (for her/her arbitrary places).