### PR TITLE
add CUDA includes if Gadgetron built with CUDA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@
 * MR/Gadgetron
   - new MR reconstruction framework sorts the ISMRMRD::Acquisitions prior to reconstruction. This ensures that only consistent images are reconstructed.
   - Encoding classes perform the Fourier transformations instead of the MRAcquisitionModel
-  - Golden-angle radial phase encoding (RPE) trajectory is supported.
+  - Golden-angle radial phase encoding (RPE) trajectory is supported if `Gadgetron` toolboxes were found during building<br />
+    **WARNING** if Gadgetron was compiled with CUDA support, you need to build SIRF with the `Gadgetron_USE_CUDA` CMake variable set to `ON`.
   - CoilSensitivitiesVector class now has forward and backward method using the encoding classes getting rid of the duplicate FFT code used to compute coil sensitivities from MRAcquisitionData.
   - added constructor for GadgetronImagesVector from MRAcquisitionData. This allows setting up an MR acquisition model without having to perform a reconstruction before. 
 

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -83,6 +83,16 @@ target_include_directories(cgadgetron PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_
 target_include_directories(cgadgetron PUBLIC "${cGadgetron_INCLUDE_DIR}")
 target_include_directories(cgadgetron PRIVATE "${FFTW3_INCLUDE_DIR}")
 target_include_directories(cgadgetron PUBLIC "${ISMRMRD_INCLUDE_DIR}")
+if (Gadgetron_USE_CUDA)
+  find_package(CUDA)
+  if (CUDA_FOUND)
+    message(STATUS "<<<<<<<<<<<<<<<<< CUDA FOUND >>>>>>>>>>>>>>>>>>>>>")
+    message(STATUS "Will enable CUDA dependencies where possible.")
+    target_include_directories(cgadgetron PUBLIC "${CUDA_INCLUDE_DIRS}")
+  else()
+	  message(FATAL_ERROR "CUDA not found and Gadgetron is built with CUDA. Cannot compile.")
+  endif()
+endif()
 
 target_link_libraries(cgadgetron PUBLIC iutilities csirf)
 # Add boost library dependencies

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -68,6 +68,21 @@ if(GT_CPUCORE AND GT_FFT AND GT_NFFT AND GT_LOG)
     else()
       add_compile_definitions(GADGETRON_TOOLBOXES_AVAILABLE)
     endif()
+    if (Gadgetron_USE_CUDA)
+        find_package(CUDA)
+        if (CUDA_FOUND)
+            message(STATUS "<<<<<<<<<<<<<<<<< CUDA FOUND >>>>>>>>>>>>>>>>>>>>>")
+            message(STATUS "Will enable CUDA dependencies for Gadgetron.")
+            target_include_directories(cgadgetron PUBLIC "${CUDA_INCLUDE_DIRS}")
+	    # might need gadgetron_toolbox_gpucore as well
+	    list(APPEND GT_LIBS ${CUDA_LIBRARIES}
+	       ${CUDA_CUFFT_LIBRARIES}
+	       ${CUDA_CUBLAS_LIBRARIES}
+	       ${CUDA_CUSPARSE_LIBRARIES})
+         else()
+	    message(FATAL_ERROR "CUDA not found and Gadgetron is built with CUDA. Cannot compile.")
+         endif()
+      endif()
 else()
     set(GADGETRON_TOOLBOXES_AVAILABLE FALSE)
     MESSAGE(WARNING "The Gadgetron Toolboxes required for radial gridding were NOT FOUND. Non-cartesian encoding will NOT BE compiled.")
@@ -83,16 +98,6 @@ target_include_directories(cgadgetron PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_
 target_include_directories(cgadgetron PUBLIC "${cGadgetron_INCLUDE_DIR}")
 target_include_directories(cgadgetron PRIVATE "${FFTW3_INCLUDE_DIR}")
 target_include_directories(cgadgetron PUBLIC "${ISMRMRD_INCLUDE_DIR}")
-if (Gadgetron_USE_CUDA)
-  find_package(CUDA)
-  if (CUDA_FOUND)
-    message(STATUS "<<<<<<<<<<<<<<<<< CUDA FOUND >>>>>>>>>>>>>>>>>>>>>")
-    message(STATUS "Will enable CUDA dependencies where possible.")
-    target_include_directories(cgadgetron PUBLIC "${CUDA_INCLUDE_DIRS}")
-  else()
-	  message(FATAL_ERROR "CUDA not found and Gadgetron is built with CUDA. Cannot compile.")
-  endif()
-endif()
 
 target_link_libraries(cgadgetron PUBLIC iutilities csirf)
 # Add boost library dependencies


### PR DESCRIPTION
When Gadgetron is built with CUDA, `gadgetron_x.cpp` needs to have those includes.