### PR TITLE
Fix flag checking for CSM computation

### DIFF
--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1730,9 +1730,13 @@ std::unique_ptr<MRAcquisitionData> CoilImagesVector::extract_calibration_data(co
 
     if(ad.get_trajectory_type() == ISMRMRD::TrajectoryType::CARTESIAN)
     {   
-        std::vector<int> flagged_positions = ad.get_flagged_acquisitions_index(calibration_flags);
+        std::vector<int> idx_calib_acquisitions = ad.get_flagged_acquisitions_index(calibration_flags);
+        
+        if(idx_calib_acquisitions.size() < 1)
+            return uptr_calib_ad;
+
         uptr_calib_ad->empty();
-        ad.get_subset(*(uptr_calib_ad), flagged_positions);
+        ad.get_subset(*(uptr_calib_ad), idx_calib_acquisitions);
         uptr_calib_ad->sort_by_time();
     }
     return uptr_calib_ad;

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -343,7 +343,7 @@ namespace sirf {
         */
         void organise_kspace();
 
-		virtual void keep_flagged_acquisitions(const std::vector<ISMRMRD::ISMRMRD_AcquisitionFlags> flags);
+		virtual std::vector<int> get_flagged_acquisitions_index(const std::vector<ISMRMRD::ISMRMRD_AcquisitionFlags> flags) const;
 
         virtual void get_subset(MRAcquisitionData& subset, const std::vector<int> subset_idx) const;
         virtual void set_subset(const MRAcquisitionData &subset, const std::vector<int> subset_idx);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -1061,7 +1061,8 @@ namespace sirf {
         CoilImagesVector() : GadgetronImagesVector(){}
         void calculate(const MRAcquisitionData& ad);
     protected:
-        gadgetron::shared_ptr<FourierEncoding> sptr_enc_;
+		std::unique_ptr<MRAcquisitionData> extract_calibration_data(const MRAcquisitionData& ad) const;
+	    gadgetron::shared_ptr<FourierEncoding> sptr_enc_;
     };
 
     /*!


### PR DESCRIPTION
This is a fix of the shift of the last CSM fix into the C++ layer (I don't know what the hell I had tested there).

The strategy is the same:
- `CoilImagesVector::calculate(MRAcquisitionData& )` extracts a subset of the acquisitions that carry a flag that marks them as coil calibration data.
- if none of the acquisitions has that flag, then all acquisitions are used.

The problem with the current code is that the `ISMRMRD::Acquisition::isFlagSet()` method behaves unexpectedly and I don't know why. I will open an issue for it. Right now I use a different approach to check for which flags are set.

New things:

*I wrote a method `CoilImagesVector::extract_calibration_data` 
*I check if the flags are set without the `ISMRMRD` methods 