### PR TITLE
Use ISMRMRD methods in flag checking

### DIFF
--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1730,9 +1730,13 @@ std::unique_ptr<MRAcquisitionData> CoilImagesVector::extract_calibration_data(co
 
     if(ad.get_trajectory_type() == ISMRMRD::TrajectoryType::CARTESIAN)
     {   
-        std::vector<int> flagged_positions = ad.get_flagged_acquisitions_index(calibration_flags);
+        std::vector<int> idx_calib_acquisitions = ad.get_flagged_acquisitions_index(calibration_flags);
+        
+        if(idx_calib_acquisitions.size() < 1)
+            return uptr_calib_ad;
+
         uptr_calib_ad->empty();
-        ad.get_subset(*(uptr_calib_ad), flagged_positions);
+        ad.get_subset(*(uptr_calib_ad), idx_calib_acquisitions);
         uptr_calib_ad->sort_by_time();
     }
     return uptr_calib_ad;

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1691,15 +1691,15 @@ CoilImagesVector::calculate(const MRAcquisitionData& ad)
     else
         throw std::runtime_error("Only cartesian or OTHER type of trajectory are available.");
 
-    std::unique_ptr<MRAcquisitionData> sptr_calib_data = this->extract_calibration_data(ad);
+    std::unique_ptr<MRAcquisitionData> uptr_calib_data = this->extract_calibration_data(ad);
     
-    this->set_meta_data(sptr_calib_data->acquisitions_info());
-    auto sort_idx = sptr_calib_data->get_kspace_order();
+    this->set_meta_data(uptr_calib_data->acquisitions_info());
+    auto sort_idx = uptr_calib_data->get_kspace_order();
 
     for(int i=0; i<sort_idx.size(); ++i)
     {
         sirf::AcquisitionsVector subset;
-        sptr_calib_data->get_subset(subset, sort_idx[i]);
+        uptr_calib_data->get_subset(subset, sort_idx[i]);
 
 		CFImage* img_ptr = new CFImage();
 		ImageWrap iw(ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_CXFLOAT, img_ptr);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -712,19 +712,11 @@ std::vector<int> MRAcquisitionData::get_flagged_acquisitions_index(const std::ve
     for(int i=0; i<this->number(); ++i)
     {
         this->get_acquisition(i, acq);
+        bool one_flag_is_set = false;
         
-        uint64_t current_flag =  acq.flags();
-        std::vector<ISMRMRD::ISMRMRD_AcquisitionFlags> flags_of_acquisition;
-        while(current_flag > 0)
-        {
-            unsigned short log_flag = int( std::floor(std::log2(current_flag)));
-            flags_of_acquisition.push_back( ISMRMRD::ISMRMRD_AcquisitionFlags(log_flag + 1));
-            current_flag -= std::pow(2, log_flag);
-        }            
-
-        bool const one_flag_is_set = std::find_first_of (flags.begin(), flags.end(),
-                    flags_of_acquisition.begin(), flags_of_acquisition.end()) != flags.end();
-
+        for(auto it: flags)
+            one_flag_is_set = (one_flag_is_set || acq.isFlagSet(it));
+        
         if(one_flag_is_set)
             flags_true_index.push_back(i);
     }
@@ -1699,15 +1691,15 @@ CoilImagesVector::calculate(const MRAcquisitionData& ad)
     else
         throw std::runtime_error("Only cartesian or OTHER type of trajectory are available.");
 
-    auto coil_calib_data = this->extract_calibration_data(ad);
+    std::unique_ptr<MRAcquisitionData> sptr_calib_data = this->extract_calibration_data(ad);
     
-    this->set_meta_data(coil_calib_data->acquisitions_info());
-    auto sort_idx = coil_calib_data->get_kspace_order();
+    this->set_meta_data(sptr_calib_data->acquisitions_info());
+    auto sort_idx = sptr_calib_data->get_kspace_order();
 
     for(int i=0; i<sort_idx.size(); ++i)
     {
         sirf::AcquisitionsVector subset;
-        coil_calib_data->get_subset(subset, sort_idx[i]);
+        sptr_calib_data->get_subset(subset, sort_idx[i]);
 
 		CFImage* img_ptr = new CFImage();
 		ImageWrap iw(ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_CXFLOAT, img_ptr);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -343,7 +343,7 @@ namespace sirf {
         */
         void organise_kspace();
 
-		virtual void keep_flagged_acquisitions(const std::vector<ISMRMRD::ISMRMRD_AcquisitionFlags> flags);
+		virtual std::vector<int> get_flagged_acquisitions_index(const std::vector<ISMRMRD::ISMRMRD_AcquisitionFlags> flags) const;
 
         virtual void get_subset(MRAcquisitionData& subset, const std::vector<int> subset_idx) const;
         virtual void set_subset(const MRAcquisitionData &subset, const std::vector<int> subset_idx);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -1061,7 +1061,8 @@ namespace sirf {
         CoilImagesVector() : GadgetronImagesVector(){}
         void calculate(const MRAcquisitionData& ad);
     protected:
-        gadgetron::shared_ptr<FourierEncoding> sptr_enc_;
+		std::unique_ptr<MRAcquisitionData> extract_calibration_data(const MRAcquisitionData& ad) const;
+	    gadgetron::shared_ptr<FourierEncoding> sptr_enc_;
     };
 
     /*!


### PR DESCRIPTION
This PR 
- uses ISMRMRD methods to check if acquisitions have a certain flag set or not instead of a manual implementation.
- renamed a variable according to the conventions of adding the `uptr_` prefix for unique pointers.
