### PR TITLE
Python fill/show allow numpy scalars

### DIFF
--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -24,7 +24,7 @@ Object-Oriented wrap for the cGadgetron-to-Python interface pygadgetron.py
 import abc
 import numpy
 import os
-from numbers import Number, Complex
+from numbers import Number, Complex, Integral
 try:
     import pylab
     HAVE_PYLAB = True
@@ -441,7 +441,7 @@ class ImageData(SIRF.ImageData):
             return
         data = self.as_array()
         nz = data.shape[0]
-        if type(slice) == type(1):
+        if isinstance(slice, (Integral,numpy.integer)):
             if slice < 0 or slice >= nz:
                 return
             ni = 1
@@ -1033,7 +1033,7 @@ class AcquisitionData(DataContainer):
             return
         data = numpy.transpose(self.as_array(), (1, 0, 2))
         nz = data.shape[0]
-        if type(slice) == type(1):
+        if isinstance(slice, (Integral,numpy.integer)):
             if slice < 0 or slice >= nz:
                 return
             ns = 1

--- a/src/xGadgetron/pGadgetron/tests/test1.py
+++ b/src/xGadgetron/pGadgetron/tests/test1.py
@@ -18,7 +18,8 @@ Options:
 # Created on Tue Nov 21 10:17:28 2017
 from sirf.Gadgetron import *
 from sirf.Utilities import runner, RE_PYEXT, __license__
-__version__ = "0.2.3"
+import numpy
+__version__ = "3.1.0"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 

--- a/src/xGadgetron/pGadgetron/tests/test1.py
+++ b/src/xGadgetron/pGadgetron/tests/test1.py
@@ -170,6 +170,10 @@ def test_main(rec=False, verb=False, throw=True):
     d = (images_copy.norm() - complex_images.norm())/complex_images.norm()
     print('%f is 0.0' % d)
     test.check_if_equal(1, d < 1e-6)
+    # test on fill with scalar
+    for n in (2,2.0,numpy.int32(2),numpy.int64(2),numpy.float128(2),numpy.complex(2)):
+        complex_images.fill(n)
+        test.check_if_zero_within_tolerance((complex_images-2).norm())
 
     return test.failed, test.ntest
 

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -29,7 +29,7 @@ try:
 except:
     HAVE_PYLAB = False
 import sys
-from numbers import Integral
+from numbers import Integral, Number
 from deprecation import deprecated
 
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
@@ -375,9 +375,7 @@ class ImageData(SIRF.ImageData):
             if not v.flags['C_CONTIGUOUS']:
                 v = numpy.ascontiguousarray(v)
             try_calling(pystir.cSTIR_setImageData(self.handle, v.ctypes.data))
-        elif isinstance(value, float):
-            try_calling(pystir.cSTIR_fillImage(self.handle, value))
-        elif isinstance(value, int):
+        elif isinstance(value, (Number, numpy.number)):
             try_calling(pystir.cSTIR_fillImage(self.handle, float(value)))
         else:
             raise TypeError('wrong fill value.' + \
@@ -473,7 +471,7 @@ class ImageData(SIRF.ImageData):
             return
         data = self.as_array()
         nz = data.shape[0]
-        if isinstance(slice, int):
+        if isinstance(slice, (Integral,numpy.integer)):
             if slice < 0 or slice >= nz:
                 raise IndexError('Slice index out of range')
             show_2D_array('slice %d' % slice, data[slice, :, :])
@@ -923,7 +921,7 @@ class AcquisitionData(DataContainer):
                 self.handle, value.handle))
         elif isinstance(value, float):
             try_calling(pystir.cSTIR_fillAcquisitionData(self.handle, value))
-        elif isinstance(value, int):
+        elif isinstance(value, (Integral,numpy.number)):
             try_calling(pystir.cSTIR_fillAcquisitionData(
                 self.handle, float(value)))
         else:
@@ -982,7 +980,7 @@ class AcquisitionData(DataContainer):
         if tof <0 or tof >= data.shape[0]:
             raise IndexError('TOF bin index out of range')
         nz = data.shape[1]
-        if isinstance(sino, int):
+        if isinstance(sino, (Integral,numpy.integer)):
             if sino < 0 or sino >= nz:
                 raise IndexError('Slice index out of range')
             show_2D_array('sinogram %d' % sino, data[tof, sino, :, :])

--- a/src/xSTIR/pSTIR/tests/tests_two.py
+++ b/src/xSTIR/pSTIR/tests/tests_two.py
@@ -16,7 +16,8 @@ Options:
 import math
 from sirf.STIR import *
 from sirf.Utilities import runner, RE_PYEXT, __license__
-__version__ = "0.2.4"
+import numpy
+__version__ = "3.1.0"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 def test_main(rec=False, verb=False, throw=True):

--- a/src/xSTIR/pSTIR/tests/tests_two.py
+++ b/src/xSTIR/pSTIR/tests/tests_two.py
@@ -160,6 +160,10 @@ def test_main(rec=False, verb=False, throw=True):
         d = numpy.linalg.norm(im2_arr - im_arr/2)
         print('images division (with out=) error: %.1e' % d)
         test.check_if_equal(0, d)
+        # test on fill with scalar
+        for n in (2,2.0,numpy.int32(2),numpy.int64(2),numpy.float128(2)):
+            image.fill(n)
+            test.check_if_zero_within_tolerance((image-2).norm())
 
     return test.failed, test.ntest
 


### PR DESCRIPTION
Gadgetron and STIR containers show methods only accepted Python int. Now can be a numpy integral type as well.

STIR containers fill method only accepted Python float or int scalars. Now can be a numpy scalar as well.
This was already possible for Gadgetron data containers, but this commit adds tests for it.

Fixes #961