### PR TITLE
Missing import in PET osem_gpu example

### DIFF
--- a/examples/Python/PET/osem_reconstruction_gpu.py
+++ b/examples/Python/PET/osem_reconstruction_gpu.py
@@ -49,7 +49,7 @@ from docopt import docopt
 args = docopt(__doc__, version=__version__)
 
 from ast import literal_eval
-
+import os
 
 def file_exists(filename):
     """Check if file exists, optionally throw error if not"""


### PR DESCRIPTION
The example script fails because there is the `os.` and it's not imported:

https://github.com/johannesmayer/SIRF/blob/8d0082efd50a74a299cb39cd727a0cb6cfbb1521/examples/Python/PET/osem_reconstruction_gpu.py#L56
