### PR TITLE
consistent use of std::shared_ptr vs stir::shared_ptr

### DIFF
--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -20,8 +20,8 @@ limitations under the License.
 */
 
 #include "sirf/common/iequals.h"
-#include "sirf/iUtilities/DataHandle.h"
 #include "sirf/STIR/stir_types.h"
+#include "sirf/iUtilities/DataHandle.h"
 #include "sirf/STIR/cstir_p.h"
 #include "sirf/STIR/stir_x.h"
 #include "stir/ImagingModality.h"
@@ -32,9 +32,9 @@ limitations under the License.
 using namespace stir;
 using namespace sirf;
 
-#define NEW_OBJECT_HANDLE(T) new ObjectHandle<T >(shared_ptr<T >(new T))
+#define NEW_OBJECT_HANDLE(T) new ObjectHandle<T >(std::shared_ptr<T >(new T))
 #define SPTR_FROM_HANDLE(Object, X, H) \
-	shared_ptr<Object> X; getObjectSptrFromHandle<Object>(H, X);
+  std::shared_ptr<Object> X; getObjectSptrFromHandle<Object>(H, X);
 
 static void*
 unknownObject(const char* obj, const char* name, const char* file, int line)
@@ -56,11 +56,11 @@ cSTIR_newReconstructionMethod(const char* par_file)
 {
 	try {
 		if (strlen(par_file) > 0) {
-			shared_ptr<Reconstruction<Image3DF> > sptr(new Method(par_file));
+                        std::shared_ptr<Reconstruction<Image3DF> > sptr(new Method(par_file));
 			return newObjectHandle(sptr);
 		}
 		else {
-			shared_ptr<Reconstruction<Image3DF> > sptr(new Method);
+                        std::shared_ptr<Reconstruction<Image3DF> > sptr(new Method);
 			return newObjectHandle(sptr);
 		}
 	}
@@ -289,12 +289,12 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 			<OSSPSReconstruction<Image3DF> >
 			(filename);
 		if (sirf::iequals(name, "Image")) {
-			shared_ptr<STIRImageData> sptr(new STIRImageData(filename));
+                        std::shared_ptr<STIRImageData> sptr(new STIRImageData(filename));
 			return newObjectHandle(sptr);
 		}
 		if (sirf::iequals(name, "AcquisitionData")) {
 
-            shared_ptr<PETAcquisitionData> sptr;
+            std::shared_ptr<PETAcquisitionData> sptr;
             if (PETAcquisitionData::storage_scheme().compare("file") == 0)
                 sptr.reset(new PETAcquisitionDataInFile(filename));
             else
@@ -302,17 +302,17 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 			return newObjectHandle(sptr);
 		}
 		if (sirf::iequals(name, "ListmodeToSinograms")) {
-			shared_ptr<ListmodeToSinograms>
+                        std::shared_ptr<ListmodeToSinograms>
 				sptr(new ListmodeToSinograms(filename));
 			return newObjectHandle(sptr);
 		}
                 if (sirf::iequals(name, "PETSingleScatterSimulator")) {
-                  shared_ptr<PETSingleScatterSimulator>
+                    stir::shared_ptr<PETSingleScatterSimulator>
                     sptr(new PETSingleScatterSimulator(filename));
                   return newObjectHandle(sptr);
                 }
                 if (sirf::iequals(name, "PETScatterEstimator")) {
-                  shared_ptr<PETScatterEstimator>
+                  stir::shared_ptr<PETScatterEstimator>
                     sptr(new PETScatterEstimator(filename));
                   return newObjectHandle(sptr);
                 }
@@ -699,7 +699,7 @@ void* cSTIR_acquisitionDataFromTemplate(void* ptr_t)
 {
 	try {
 		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_t, ptr_t);
-		shared_ptr<PETAcquisitionData> sptr(sptr_t->new_acquisition_data());
+                std::shared_ptr<PETAcquisitionData> sptr(sptr_t->new_acquisition_data());
 		return newObjectHandle(sptr);
 	}
 	CATCH;
@@ -710,7 +710,7 @@ void* cSTIR_cloneAcquisitionData(void* ptr_ad)
 {
 	try {
 		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_ad);
-		shared_ptr<PETAcquisitionData> sptr(sptr_ad->clone());
+                std::shared_ptr<PETAcquisitionData> sptr(sptr_ad->clone());
 		return newObjectHandle(sptr);
 	}
 	CATCH;
@@ -727,7 +727,7 @@ const int max_in_segment_num_to_process
 {
 	try {
 		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_t, ptr_t);
-		shared_ptr<PETAcquisitionData> sptr =
+                std::shared_ptr<PETAcquisitionData> sptr =
 			sptr_t->single_slice_rebinned_data(
 			num_segments_to_combine,
 			num_views_to_combine,
@@ -745,15 +745,15 @@ void* cSTIR_acquisitionDataFromScannerInfo
 (const char* scanner, int span, int max_ring_diff, int view_mash_factor)
 {
 	try{
-		shared_ptr<ExamInfo> sptr_ei(new ExamInfo());
+                stir::shared_ptr<ExamInfo> sptr_ei(new ExamInfo());
         sptr_ei->imaging_modality = ImagingModality::PT;
 		stir::shared_ptr<stir::ProjDataInfo> sptr_pdi =
 			PETAcquisitionData::proj_data_info_from_scanner
 			(scanner, span, max_ring_diff, view_mash_factor);
 		PETAcquisitionDataInFile::init();
-		stir::shared_ptr<PETAcquisitionData> sptr_t =
+		std::shared_ptr<PETAcquisitionData> sptr_t =
 			PETAcquisitionData::storage_template();
-		stir::shared_ptr<PETAcquisitionData> sptr(sptr_t->same_acquisition_data
+		std::shared_ptr<PETAcquisitionData> sptr(sptr_t->same_acquisition_data
 			(sptr_ei, sptr_pdi));
 		sptr->fill(0.0f);
 		return newObjectHandle(sptr);

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -22,8 +22,8 @@ limitations under the License.
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "sirf/iUtilities/DataHandle.h"
 #include "sirf/STIR/stir_types.h"
+#include "sirf/iUtilities/DataHandle.h"
 #include "sirf/STIR/cstir_p.h"
 #include "sirf/STIR/stir_x.h"
 
@@ -31,7 +31,9 @@ using namespace stir;
 using namespace sirf;
 
 #define SPTR_FROM_HANDLE(Object, X, H) \
-	shared_ptr<Object> X; getObjectSptrFromHandle<Object>(H, X);
+  std::shared_ptr<Object> X; getObjectSptrFromHandle<Object>(H, X);
+#define STIRSPTR_FROM_HANDLE(Object, X, H) \
+  stir::shared_ptr<Object> X; getObjectSptrFromHandle<Object>(H, X);
 #define SIRF_DYNAMIC_CAST(T, X, Y) T& X = dynamic_cast<T&>(Y)
 
 extern "C"
@@ -271,7 +273,7 @@ sirf::cSTIR_setAcquisitionModelParameter
 		am.set_asm(sptr_asm);
 	}
 	else if (sirf::iequals(name, "image_data_processor")) {
-		SPTR_FROM_HANDLE(ImageDataProcessor, sptr_proc, hv);
+		STIRSPTR_FROM_HANDLE(ImageDataProcessor, sptr_proc, hv);
 		am.set_image_data_processor(sptr_proc);
 	}
 	else
@@ -298,7 +300,7 @@ sirf::cSTIR_setAcqModUsingMatrixParameter
 {
 	AcqModUsingMatrix3DF& am = objectFromHandle<AcqModUsingMatrix3DF>(hm);
 	if (sirf::iequals(name, "matrix")) {
-		SPTR_FROM_HANDLE(ProjMatrixByBin, sptr_m, hv);
+		STIRSPTR_FROM_HANDLE(ProjMatrixByBin, sptr_m, hv);
 		am.set_matrix(sptr_m);
 	}
 	else
@@ -520,7 +522,7 @@ sirf::cSTIR_setGeneralisedObjectiveFunctionParameter
 	ObjectiveFunction3DF& obj_fun =
 		objectFromHandle< ObjectiveFunction3DF >(hp);
 	if (sirf::iequals(name, "prior")) {
-		SPTR_FROM_HANDLE(GeneralisedPrior<Image3DF>, sptr_p, hv);
+		STIRSPTR_FROM_HANDLE(GeneralisedPrior<Image3DF>, sptr_p, hv);
 		obj_fun.set_prior_sptr(sptr_p);
 	}
 	else if (sirf::iequals(name, "num_subsets"))
@@ -635,11 +637,11 @@ sirf::cSTIR_setIterativeReconstructionParameter
 	IterativeReconstruction3DF& recon =
 		objectFromHandle<IterativeReconstruction3DF>(hp);
 	if (sirf::iequals(name, "inter_iteration_filter_type")) {
-		SPTR_FROM_HANDLE(DataProcessor3DF, sptr_f, hv);
+		STIRSPTR_FROM_HANDLE(DataProcessor3DF, sptr_f, hv);
 		recon.set_inter_iteration_filter_ptr(sptr_f);
 	}
 	else if (sirf::iequals(name, "objective_function")) {
-		SPTR_FROM_HANDLE(ObjectiveFunction3DF, sptr_obf, hv);
+		STIRSPTR_FROM_HANDLE(ObjectiveFunction3DF, sptr_obf, hv);
 		recon.set_objective_function_sptr(sptr_obf);
 	}
 	else if (sirf::iequals(name, "initial_estimate")) {

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -38,6 +38,7 @@ limitations under the License.
 #include <fstream>
 #include <exception>
 
+#include "sirf/STIR/stir_types.h"
 #include "sirf/iUtilities/LocalisedException.h"
 #include "sirf/iUtilities/DataHandle.h"
 #include "sirf/common/iequals.h"
@@ -45,7 +46,6 @@ limitations under the License.
 #include "sirf/common/DataContainer.h"
 #include "sirf/common/ANumRef.h"
 #include "sirf/common/PETImageData.h"
-#include "sirf/STIR/stir_types.h"
 #include "sirf/common/GeometricalInfo.h"
 #include "stir/ZoomOptions.h"
 
@@ -153,7 +153,7 @@ namespace sirf {
 		virtual PETAcquisitionData* same_acquisition_data
 			(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
 			stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info) const = 0;
-		virtual stir::shared_ptr<PETAcquisitionData> new_acquisition_data() const = 0;
+		virtual std::shared_ptr<PETAcquisitionData> new_acquisition_data() const = 0;
 
 		virtual bool is_complex() const
 		{
@@ -175,7 +175,7 @@ namespace sirf {
 		  \param max_in_segment_num_to_process by default all input data are used. If set to a non-negative
 		    number, it will remove the most oblique segments.
 		*/
-		stir::shared_ptr<PETAcquisitionData> single_slice_rebinned_data(
+		std::shared_ptr<PETAcquisitionData> single_slice_rebinned_data(
 			const int num_segments_to_combine,
 			const int num_views_to_combine = 1,
 			const int num_tang_poss_to_trim = 0,
@@ -190,7 +190,7 @@ namespace sirf {
 				num_tang_poss_to_trim,
 				max_in_segment_num_to_process
 				));
-			stir::shared_ptr<PETAcquisitionData> 
+			std::shared_ptr<PETAcquisitionData> 
 				sptr(same_acquisition_data
                                      (this->get_exam_info_sptr(), out_proj_data_info_sptr));
 			SSRB(*sptr, *data(), do_normalisation);
@@ -206,7 +206,7 @@ namespace sirf {
 			}
 			return _storage_scheme;
 		}
-		static stir::shared_ptr<PETAcquisitionData> storage_template()
+		static std::shared_ptr<PETAcquisitionData> storage_template()
 		{
 			return _template;
 		}
@@ -377,7 +377,7 @@ namespace sirf {
 
 	protected:
 		static std::string _storage_scheme;
-		static stir::shared_ptr<PETAcquisitionData> _template;
+		static std::shared_ptr<PETAcquisitionData> _template;
 		stir::shared_ptr<stir::ProjData> _data;
 		virtual PETAcquisitionData* clone_impl() const = 0;
 		PETAcquisitionData* clone_base() const
@@ -432,9 +432,9 @@ namespace sirf {
 			ptr->fill(0.0f);
 			_data.reset(ptr);
 		}
-		stir::shared_ptr<PETAcquisitionData> new_acquisition_data(std::string filename)
+		std::shared_ptr<PETAcquisitionData> new_acquisition_data(std::string filename)
 		{
-			stir::shared_ptr<PETAcquisitionDataInFile> sptr_ad(new PETAcquisitionDataInFile);
+			std::shared_ptr<PETAcquisitionDataInFile> sptr_ad(new PETAcquisitionDataInFile);
 			sptr_ad->_data.reset(new ProjDataFile(*data(), filename, false));
 			return sptr_ad;
 		}
@@ -470,12 +470,12 @@ namespace sirf {
                                 this->get_exam_info_sptr(),
 				this->get_proj_data_info_sptr()->create_shared_clone());
 			return new ObjectHandle<DataContainer>
-				(stir::shared_ptr<DataContainer>(ptr));
+				(std::shared_ptr<DataContainer>(ptr));
 		}
-		virtual stir::shared_ptr<PETAcquisitionData> new_acquisition_data() const
+		virtual std::shared_ptr<PETAcquisitionData> new_acquisition_data() const
 		{
 			init();
-			return stir::shared_ptr < PETAcquisitionData >
+			return std::shared_ptr < PETAcquisitionData >
 				(_template->same_acquisition_data(this->get_exam_info_sptr(),
 				this->get_proj_data_info_sptr()->create_shared_clone()));
 		}
@@ -568,12 +568,12 @@ namespace sirf {
 				(this->get_exam_info_sptr(),
                                  this->get_proj_data_info_sptr()->create_shared_clone());
 			return new ObjectHandle<DataContainer>
-				(stir::shared_ptr<DataContainer>(ptr));
+				(std::shared_ptr<DataContainer>(ptr));
 		}
-		virtual stir::shared_ptr<PETAcquisitionData> new_acquisition_data() const
+		virtual std::shared_ptr<PETAcquisitionData> new_acquisition_data() const
 		{
 			init();
-			return stir::shared_ptr < PETAcquisitionData >
+			return std::shared_ptr < PETAcquisitionData >
 				(_template->same_acquisition_data
 				(this->get_exam_info_sptr(),
                                  this->get_proj_data_info_sptr()->create_shared_clone()));
@@ -871,14 +871,14 @@ namespace sirf {
             ptr_image->set_up_geom_info();
 			return ptr_image;
 		}
-		stir::shared_ptr<STIRImageData> new_image_data()
+		std::shared_ptr<STIRImageData> new_image_data()
 		{
-			return stir::shared_ptr<STIRImageData>(same_image_data());
+			return std::shared_ptr<STIRImageData>(same_image_data());
 		}
 		virtual ObjectHandle<DataContainer>* new_data_container_handle() const
 		{
 			return new ObjectHandle<DataContainer>
-				(stir::shared_ptr<DataContainer>(same_image_data()));
+				(std::shared_ptr<DataContainer>(same_image_data()));
 		}
 		virtual bool is_complex() const
 		{
@@ -1064,10 +1064,10 @@ namespace sirf {
 	protected:
 
 		stir::shared_ptr<Image3DF> _data;
-		mutable stir::shared_ptr<Iterator> _begin;
-		mutable stir::shared_ptr<Iterator> _end;
-		mutable stir::shared_ptr<Iterator_const> _begin_const;
-		mutable stir::shared_ptr<Iterator_const> _end_const;
+		mutable std::shared_ptr<Iterator> _begin;
+		mutable std::shared_ptr<Iterator> _end;
+		mutable std::shared_ptr<Iterator_const> _begin_const;
+		mutable std::shared_ptr<Iterator_const> _end_const;
 	};
 
 }  // namespace sirf

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_types.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_types.h
@@ -107,4 +107,8 @@ namespace sirf {
 
 }
 
+#ifdef STIR_USE_BOOST_SHARED_PTR
+#define USE_BOOST //KTXXXX
+#endif
+
 #endif

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -183,7 +183,7 @@ The actual algorithm is described in
 			exam_info_sptr_->set_time_frame_definitions(frame_defs);
 			const float h = proj_data_info_sptr_->get_bed_position_horizontal();
 			const float v = proj_data_info_sptr_->get_bed_position_vertical();
-			shared_ptr<ProjDataInfo> temp_proj_data_info_sptr(template_proj_data_info_ptr->clone());
+                        stir::shared_ptr<ProjDataInfo> temp_proj_data_info_sptr(template_proj_data_info_ptr->clone());
 			temp_proj_data_info_sptr->set_bed_position_horizontal(h);
 			temp_proj_data_info_sptr->set_bed_position_vertical(v);
 			randoms_sptr.reset(new PETAcquisitionDataInMemory(exam_info_sptr_, temp_proj_data_info_sptr));
@@ -196,13 +196,13 @@ The actual algorithm is described in
 			std::string filename = output_filename_prefix + "_randoms" + "_f1g1d0b0.hs";
 			randoms_sptr->write(filename.c_str());
 		}
-		stir::shared_ptr<PETAcquisitionData> get_output()
+		std::shared_ptr<PETAcquisitionData> get_output()
 		{
 			std::string filename = output_filename_prefix + "_f1g1d0b0.hs";
-			return stir::shared_ptr<PETAcquisitionData>
+			return std::shared_ptr<PETAcquisitionData>
 				(new PETAcquisitionDataInFile(filename.c_str()));
 		}
-		stir::shared_ptr<PETAcquisitionData> get_randoms_sptr()
+		std::shared_ptr<PETAcquisitionData> get_randoms_sptr()
 		{
 			return randoms_sptr;
 		}
@@ -223,7 +223,7 @@ The actual algorithm is described in
 		stir::shared_ptr<ProjDataInfo> proj_data_info_sptr_;
 		stir::shared_ptr<std::vector<stir::Array<2, float> > > fan_sums_sptr;
 		stir::shared_ptr<stir::DetectorEfficiencies> det_eff_sptr;
-		stir::shared_ptr<PETAcquisitionData> randoms_sptr;
+		std::shared_ptr<PETAcquisitionData> randoms_sptr;
 		void compute_fan_sums_(bool prompt_fansum = false);
 		int compute_singles_();
 //		void estimate_randoms_();
@@ -260,17 +260,17 @@ The actual algorithm is described in
 		// divide by bin efficiencies
 		virtual void normalise(PETAcquisitionData& ad) const;
 		// same as apply, but returns new data rather than changes old one
-		stir::shared_ptr<PETAcquisitionData> forward(PETAcquisitionData& ad) const
+		std::shared_ptr<PETAcquisitionData> forward(PETAcquisitionData& ad) const
 		{
-			stir::shared_ptr<PETAcquisitionData> sptr_ad = ad.new_acquisition_data();
+			std::shared_ptr<PETAcquisitionData> sptr_ad = ad.new_acquisition_data();
 			sptr_ad->fill(ad);
 			this->unnormalise(*sptr_ad);
 			return sptr_ad;
 		}
 		// same as undo, but returns new data rather than changes old one
-		stir::shared_ptr<PETAcquisitionData> invert(PETAcquisitionData& ad) const
+		std::shared_ptr<PETAcquisitionData> invert(PETAcquisitionData& ad) const
 		{
-			stir::shared_ptr<PETAcquisitionData> sptr_ad = ad.new_acquisition_data();
+			std::shared_ptr<PETAcquisitionData> sptr_ad = ad.new_acquisition_data();
 			sptr_ad->fill(ad);
 			this->normalise(*sptr_ad);
 			return sptr_ad;
@@ -396,27 +396,27 @@ The actual algorithm is described in
 		{
 			return sptr_projectors_;
 		}
-		void set_additive_term(stir::shared_ptr<PETAcquisitionData> sptr)
+		void set_additive_term(std::shared_ptr<PETAcquisitionData> sptr)
 		{
 			sptr_add_ = sptr;
 		}
-		stir::shared_ptr<const PETAcquisitionData> additive_term_sptr() const
+		std::shared_ptr<const PETAcquisitionData> additive_term_sptr() const
 		{
 			return sptr_add_;
 		}
-		void set_background_term(stir::shared_ptr<PETAcquisitionData> sptr)
+		void set_background_term(std::shared_ptr<PETAcquisitionData> sptr)
 		{
 			sptr_background_ = sptr;
 		}
-		stir::shared_ptr<const PETAcquisitionData> background_term_sptr() const
+		std::shared_ptr<const PETAcquisitionData> background_term_sptr() const
 		{
 			return sptr_background_;
 		}
-		stir::shared_ptr<const PETAcquisitionData> acq_template_sptr() const
+		std::shared_ptr<const PETAcquisitionData> acq_template_sptr() const
 		{
 			return sptr_acq_template_;
 		}
-		stir::shared_ptr<const STIRImageData> image_template_sptr() const
+		std::shared_ptr<const STIRImageData> image_template_sptr() const
 		{
 			return sptr_image_template_;
 		}
@@ -437,7 +437,7 @@ The actual algorithm is described in
 		//{
 		//	sptr_normalisation_.reset(new stir::BinNormalisationFromProjData(*sptr_data));
 		//}
-		void set_asm(stir::shared_ptr<PETAcquisitionSensitivityModel> sptr_asm)
+		void set_asm(std::shared_ptr<PETAcquisitionSensitivityModel> sptr_asm)
 		{
 			//sptr_normalisation_ = sptr_asm->data();
 			sptr_asm_ = sptr_asm;
@@ -460,9 +460,9 @@ The actual algorithm is described in
 			sptr_asm_.reset();
 			//sptr_normalisation_.reset();
 		}
-		stir::shared_ptr<const PETAcquisitionModel> linear_acq_mod_sptr() const
+		std::shared_ptr<const PETAcquisitionModel> linear_acq_mod_sptr() const
 		{
-			stir::shared_ptr<PETAcquisitionModel> sptr_am(new PETAcquisitionModel);
+			std::shared_ptr<PETAcquisitionModel> sptr_am(new PETAcquisitionModel);
 			sptr_am->set_projectors(sptr_projectors_);
 			sptr_am->set_asm(sptr_asm_);
 			sptr_am->sptr_acq_template_ = sptr_acq_template_;
@@ -471,13 +471,13 @@ The actual algorithm is described in
 		}
 
 		virtual void set_up(
-			stir::shared_ptr<PETAcquisitionData> sptr_acq,
-			stir::shared_ptr<STIRImageData> sptr_image);
+			std::shared_ptr<PETAcquisitionData> sptr_acq,
+			std::shared_ptr<STIRImageData> sptr_image);
 
 		/*! \brief computes and returns a subset of forward-projected data
 		\see forward(PETAcquisitionData&, const STIRImageData&,, int, int, bool, bool)
 		*/
-		stir::shared_ptr<PETAcquisitionData>
+		std::shared_ptr<PETAcquisitionData>
 			forward(const STIRImageData& image,
 			int subset_num = 0, int num_subsets = 1, bool do_linear_only = false) const;
 		/*! \brief replaces a subset of acquisition data with forward-projected data
@@ -494,7 +494,7 @@ The actual algorithm is described in
 			int subset_num, int num_subsets, bool zero = false, bool do_linear_only = false) const;
 
 		// computes and returns back-projected subset of acquisition data 
-		stir::shared_ptr<STIRImageData> backward(PETAcquisitionData& ad,
+		std::shared_ptr<STIRImageData> backward(PETAcquisitionData& ad,
 			int subset_num = 0, int num_subsets = 1) const;
 		// puts back-projected subset of acquisition data into image 
 		void backward(STIRImageData& image, PETAcquisitionData& ad,
@@ -502,11 +502,11 @@ The actual algorithm is described in
 
 	protected:
 		stir::shared_ptr<stir::ProjectorByBinPair> sptr_projectors_;
-		stir::shared_ptr<PETAcquisitionData> sptr_acq_template_;
-		stir::shared_ptr<STIRImageData> sptr_image_template_;
-		stir::shared_ptr<PETAcquisitionData> sptr_add_;
-		stir::shared_ptr<PETAcquisitionData> sptr_background_;
-		stir::shared_ptr<PETAcquisitionSensitivityModel> sptr_asm_;
+		std::shared_ptr<PETAcquisitionData> sptr_acq_template_;
+		std::shared_ptr<STIRImageData> sptr_image_template_;
+		std::shared_ptr<PETAcquisitionData> sptr_add_;
+		std::shared_ptr<PETAcquisitionData> sptr_background_;
+		std::shared_ptr<PETAcquisitionSensitivityModel> sptr_asm_;
 		//shared_ptr<stir::BinNormalisation> sptr_normalisation_;
 	};
 
@@ -533,8 +533,8 @@ The actual algorithm is described in
         stir::SingleScatterSimulation(filename)
         {}
 
-        void set_up(shared_ptr<const PETAcquisitionData> sptr_acq_template,
-                    shared_ptr<const STIRImageData> sptr_act_image_template)
+        void set_up(std::shared_ptr<const PETAcquisitionData> sptr_acq_template,
+                    std::shared_ptr<const STIRImageData> sptr_act_image_template)
           {
             this->sptr_acq_template_ = sptr_acq_template;
 
@@ -557,7 +557,7 @@ The actual algorithm is described in
               THROW("Fatal error in PETSingleScatterSimulator::set_up() failed.");
           }
 
-        void set_activity_image_sptr(stir::shared_ptr<const STIRImageData> arg)
+        void set_activity_image_sptr(std::shared_ptr<const STIRImageData> arg)
         {
 #if STIR_VERSION < 050000
             // need to make a copy as the function doesn't accept a const
@@ -568,7 +568,7 @@ The actual algorithm is described in
 #endif
         }
 
-        void set_attenuation_image_sptr(stir::shared_ptr<const STIRImageData> arg)
+        void set_attenuation_image_sptr(std::shared_ptr<const STIRImageData> arg)
         {
 #if STIR_VERSION < 050000
             // need to make a copy as the function doesn't accept a const
@@ -579,26 +579,26 @@ The actual algorithm is described in
 #endif
         }
 
-        stir::shared_ptr<PETAcquisitionData> forward(const STIRImageData& activity_img) /*TODO CONST*/
+        std::shared_ptr<PETAcquisitionData> forward(const STIRImageData& activity_img) /*TODO CONST*/
           {
             if (!sptr_acq_template_.get())
               THROW("Fatal error in PETSingleScatterSimulator::forward: acquisition template not set");
-            shared_ptr<PETAcquisitionData> sptr_ad;
-            sptr_ad = sptr_acq_template_->new_acquisition_data();
+            std::shared_ptr<PETAcquisitionData> sptr_ad =
+              sptr_acq_template_->new_acquisition_data();
             this->forward( *sptr_ad, activity_img);
             return sptr_ad;
           }
 
         void forward(PETAcquisitionData& ad, const STIRImageData& activity_img) /* TODO CONST*/
           {
-            shared_ptr<ProjData> sptr_fd = ad.data();
+            stir::shared_ptr<ProjData> sptr_fd = ad.data();
             this->set_output_proj_data_sptr(sptr_fd);
             // hopefully STIR checks if template consistent with input data
             this->process_data();
           }
 
     protected:
-        stir::shared_ptr<const PETAcquisitionData> sptr_acq_template_;
+        std::shared_ptr<const PETAcquisitionData> sptr_acq_template_;
 
     };
 
@@ -640,27 +640,27 @@ The actual algorithm is described in
         {}
 
         //! Set the input data
-        void set_input_sptr(stir::shared_ptr<const PETAcquisitionData> arg)
+        void set_input_sptr(std::shared_ptr<const PETAcquisitionData> arg)
         {
             stir::ScatterEstimation::set_input_proj_data_sptr(arg->data());
         }
         //! Set attenuation correction factors as acq_data
-        void set_attenuation_correction_factors_sptr(stir::shared_ptr<const PETAcquisitionData> arg)
+        void set_attenuation_correction_factors_sptr(std::shared_ptr<const PETAcquisitionData> arg)
         {
           stir::ScatterEstimation::set_attenuation_correction_proj_data_sptr(arg->data());
         }
         //! Set acquisition sensitivity model specifying detection efficiencies (without attenuation)
-        void set_asm(stir::shared_ptr<PETAcquisitionSensitivityModel> arg)
+        void set_asm(std::shared_ptr<PETAcquisitionSensitivityModel> arg)
         {
           stir::ScatterEstimation::set_normalisation_sptr(arg->data());
         }
         //! Set the background data (normally equal to the randoms in PET)
-        void set_background_sptr(stir::shared_ptr<const PETAcquisitionData> arg)
+        void set_background_sptr(std::shared_ptr<const PETAcquisitionData> arg)
         {
             stir::ScatterEstimation::set_background_proj_data_sptr(arg->data());
         }
 
-        void set_attenuation_image_sptr(stir::shared_ptr<const STIRImageData> arg)
+        void set_attenuation_image_sptr(std::shared_ptr<const STIRImageData> arg)
         {
 #if STIR_VERSION < 050000
             // need to make a copy as the function doesn't accept a const
@@ -694,7 +694,7 @@ The actual algorithm is described in
           return stir::ScatterEstimation::get_num_iterations();
         }
 
-        stir::shared_ptr<PETAcquisitionData> get_scatter_estimate(int est_num = -1) const
+        std::shared_ptr<PETAcquisitionData> get_scatter_estimate(int est_num = -1) const
         {
             if (est_num == -1) // Get the last one
                 est_num = num_scatter_iterations;
@@ -708,12 +708,12 @@ The actual algorithm is described in
         }
 
         //! get last scatter estimate
-        stir::shared_ptr<PETAcquisitionData> get_output() const
+        std::shared_ptr<PETAcquisitionData> get_output() const
           {
             auto stir_proj_data_sptr = stir::ScatterEstimation::get_output();
             if (!stir_proj_data_sptr)
               THROW("output not yet computed");
-            stir::shared_ptr<PETAcquisitionData> sptr_acq_data
+            std::shared_ptr<PETAcquisitionData> sptr_acq_data
               (PETAcquisitionData::storage_template()->same_acquisition_data(stir_proj_data_sptr->get_exam_info_sptr(),
                                                                              stir_proj_data_sptr->get_proj_data_info_sptr()->create_shared_clone()));
             sptr_acq_data->data()->fill(*stir_proj_data_sptr);
@@ -782,8 +782,8 @@ The actual algorithm is described in
 				get_proj_matrix_sptr();
 		}
 		virtual	void set_up(
-			stir::shared_ptr<PETAcquisitionData> sptr_acq,
-			stir::shared_ptr<STIRImageData> sptr_image)
+			std::shared_ptr<PETAcquisitionData> sptr_acq,
+			std::shared_ptr<STIRImageData> sptr_image)
 		{
 			if (!sptr_matrix_.get())
 				THROW("PETAcquisitionModelUsingMatrix setup failed - matrix not set");
@@ -796,7 +796,7 @@ The actual algorithm is described in
 
 	typedef PETAcquisitionModel AcqMod3DF;
 	typedef PETAcquisitionModelUsingMatrix AcqModUsingMatrix3DF;
-	typedef stir::shared_ptr<AcqMod3DF> sptrAcqMod3DF;
+	typedef std::shared_ptr<AcqMod3DF> sptrAcqMod3DF;
 
 #ifdef STIR_WITH_NiftyPET_PROJECTOR
     /*!
@@ -822,7 +822,7 @@ The actual algorithm is described in
             _NiftyPET_projector_pair_sptr->set_use_truncation(use_truncation);
         }
     protected:
-        stir::shared_ptr<ProjectorPairUsingNiftyPET> _NiftyPET_projector_pair_sptr;
+        stir::shared_ptr<stir::ProjectorPairUsingNiftyPET> _NiftyPET_projector_pair_sptr;
     };
     typedef PETAcquisitionModelUsingNiftyPET AcqModUsingNiftyPET3DF;
 #endif
@@ -906,12 +906,12 @@ The actual algorithm is described in
 		void set_input_file(const char* filename) {
 			input_filename = filename;
 		}
-		void set_acquisition_data(stir::shared_ptr<PETAcquisitionData> sptr)
+		void set_acquisition_data(std::shared_ptr<PETAcquisitionData> sptr)
 		{
 			sptr_ad_ = sptr;
 			set_proj_data_sptr(sptr->data());
 		}
-		void set_acquisition_model(stir::shared_ptr<AcqMod3DF> sptr)
+		void set_acquisition_model(std::shared_ptr<AcqMod3DF> sptr)
 		{
 			sptr_am_ = sptr;
 			AcqMod3DF& am = *sptr;
@@ -921,13 +921,13 @@ The actual algorithm is described in
 			if (am.normalisation_sptr().get())
 				set_normalisation_sptr(am.normalisation_sptr());
 		}
-		stir::shared_ptr<AcqMod3DF> acquisition_model_sptr()
+		std::shared_ptr<AcqMod3DF> acquisition_model_sptr()
 		{
 			return sptr_am_;
 		}
 	private:
-		stir::shared_ptr<PETAcquisitionData> sptr_ad_;
-		stir::shared_ptr<AcqMod3DF> sptr_am_;
+		std::shared_ptr<PETAcquisitionData> sptr_ad_;
+		std::shared_ptr<AcqMod3DF> sptr_am_;
 	};
 
 	typedef xSTIR_PoissonLogLikelihoodWithLinearModelForMeanAndProjData3DF
@@ -1014,7 +1014,7 @@ The actual algorithm is described in
 				("wrong frequency cut-off", __FILE__, __LINE__);
 			fc_ramp = fc;
 		}
-		void set_up(stir::shared_ptr<STIRImageData> sptr_id)
+		void set_up(std::shared_ptr<STIRImageData> sptr_id)
 		{
 			_sptr_image_data.reset(new STIRImageData(*sptr_id));
 			stir::Succeeded s = stir::Reconstruction<Image3DF>::set_up(_sptr_image_data->data_sptr());
@@ -1040,13 +1040,13 @@ The actual algorithm is described in
 			if (s != stir::Succeeded::yes)
 				THROW("stir::AnalyticReconstruction::reconstruct failed");
 		}
-		stir::shared_ptr<STIRImageData> get_output()
+		std::shared_ptr<STIRImageData> get_output()
 		{
 			return _sptr_image_data;
 		}
 	protected:
 		bool _is_set_up;
-		stir::shared_ptr<STIRImageData> _sptr_image_data;
+		std::shared_ptr<STIRImageData> _sptr_image_data;
 	};
 
 	class xSTIR_SeparableGaussianImageFilter : 

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -31,7 +31,7 @@ using namespace sirf;
 #define SIRF_DYNAMIC_CAST(T, X, Y) T& X = dynamic_cast<T&>(Y)
 
 std::string PETAcquisitionData::_storage_scheme;
-shared_ptr<PETAcquisitionData> PETAcquisitionData::_template;
+std::shared_ptr<PETAcquisitionData> PETAcquisitionData::_template;
 
 float
 PETAcquisitionData::norm() const

--- a/src/xSTIR/cSTIR/stir_x.cpp
+++ b/src/xSTIR/cSTIR/stir_x.cpp
@@ -358,10 +358,10 @@ ListmodeToSinograms::estimate_randoms()
 PETAcquisitionSensitivityModel::
 PETAcquisitionSensitivityModel(PETAcquisitionData& ad)
 {
-	shared_ptr<PETAcquisitionData>
+        std::shared_ptr<PETAcquisitionData>
 		sptr_ad(ad.new_acquisition_data());
 	sptr_ad->inv(MIN_BIN_EFFICIENCY, ad);
-	shared_ptr<BinNormalisation> 
+        stir::shared_ptr<BinNormalisation> 
 		sptr_n(new BinNormalisationFromProjData(sptr_ad->data()));
 	//shared_ptr<BinNormalisation> sptr_0;
 	//norm_.reset(new ChainedBinNormalisation(sptr_n, sptr_0));
@@ -441,7 +441,7 @@ PETAttenuationModel::unnormalise(PETAcquisitionData& ad) const
 {
 	//std::cout << "in PETAttenuationModel::unnormalise\n";
 	BinNormalisation* norm = norm_.get();
-	shared_ptr<DataSymmetriesForViewSegmentNumbers>
+        stir::shared_ptr<DataSymmetriesForViewSegmentNumbers>
 		symmetries_sptr(sptr_forw_projector_->get_symmetries_used()->clone());
 	norm->undo(*ad.data(), 0, 1, symmetries_sptr);
 }
@@ -450,7 +450,7 @@ void
 PETAttenuationModel::normalise(PETAcquisitionData& ad) const
 {
 	BinNormalisation* norm = norm_.get();
-	shared_ptr<DataSymmetriesForViewSegmentNumbers>
+        stir::shared_ptr<DataSymmetriesForViewSegmentNumbers>
 		symmetries_sptr(sptr_forw_projector_->get_symmetries_used()->clone());
 #if STIR_VERSION < 050000
 	norm->apply(*ad.data(), 0, 1, symmetries_sptr);
@@ -463,7 +463,7 @@ PETAttenuationModel::normalise(PETAcquisitionData& ad) const
 //PETAcquisitionModel::set_bin_efficiency
 //(shared_ptr<PETAcquisitionData> sptr_data)
 //{
-//	shared_ptr<PETAcquisitionData>
+//	std::shared_ptr<PETAcquisitionData>
 //		sptr_ad(sptr_data->new_acquisition_data());
 //	sptr_ad->inv(MIN_BIN_EFFICIENCY, *sptr_data);
 //	sptr_normalisation_.reset
@@ -473,8 +473,8 @@ PETAttenuationModel::normalise(PETAcquisitionData& ad) const
 
 void
 PETAcquisitionModel::set_up(
-	shared_ptr<PETAcquisitionData> sptr_acq,
-	shared_ptr<STIRImageData> sptr_image)
+                            std::shared_ptr<PETAcquisitionData> sptr_acq,
+                            std::shared_ptr<STIRImageData> sptr_image)
 {
 	Succeeded s = Succeeded::no;
 	if (sptr_projectors_.get()) {
@@ -507,7 +507,7 @@ void
 PETAcquisitionModel::forward(PETAcquisitionData& ad, const STIRImageData& image,
 	int subset_num, int num_subsets, bool zero, bool do_linear_only) const
 {
-	shared_ptr<ProjData> sptr_fd = ad.data();
+        stir::shared_ptr<ProjData> sptr_fd = ad.data();
 	sptr_projectors_->get_forward_projector_sptr()->forward_project
 		(*sptr_fd, image.data(), subset_num, num_subsets, zero);
 
@@ -541,26 +541,26 @@ PETAcquisitionModel::forward(PETAcquisitionData& ad, const STIRImageData& image,
 		if (stir::Verbosity::get() > 1) std::cout << "no background term added\n";
 }
 
-shared_ptr<PETAcquisitionData>
+std::shared_ptr<PETAcquisitionData>
 PETAcquisitionModel::forward(const STIRImageData& image, 
 	int subset_num, int num_subsets, bool do_linear_only) const
 {
 	if (!sptr_acq_template_.get())
 		THROW("Fatal error in PETAcquisitionModel::forward: acquisition template not set");
-	shared_ptr<PETAcquisitionData> sptr_ad;
-	sptr_ad = sptr_acq_template_->new_acquisition_data();
-	shared_ptr<ProjData> sptr_fd = sptr_ad->data();
+        std::shared_ptr<PETAcquisitionData> sptr_ad =
+          sptr_acq_template_->new_acquisition_data();
+        stir::shared_ptr<ProjData> sptr_fd = sptr_ad->data();
 	forward(*sptr_ad, image, subset_num, num_subsets, num_subsets > 1, do_linear_only);
 	return sptr_ad;
 }
 
-shared_ptr<STIRImageData> 
+std::shared_ptr<STIRImageData> 
 PETAcquisitionModel::backward(PETAcquisitionData& ad,
 	int subset_num, int num_subsets) const
 {
 	if (!sptr_image_template_.get())
 		THROW("Fatal error in PETAcquisitionModel::backward: image template not set");
-	shared_ptr<STIRImageData> sptr_id;
+        std::shared_ptr<STIRImageData> sptr_id;
 	sptr_id = sptr_image_template_->new_image_data();
 	backward(*sptr_id, ad, subset_num, num_subsets);
 	return sptr_id;
@@ -570,12 +570,12 @@ void
 PETAcquisitionModel::backward(STIRImageData& id, PETAcquisitionData& ad,
 	int subset_num, int num_subsets) const
 {
-	shared_ptr<Image3DF> sptr_im = id.data_sptr();
+        stir::shared_ptr<Image3DF> sptr_im = id.data_sptr();
 
 	PETAcquisitionSensitivityModel* sm = sptr_asm_.get();
 	if (sm && sm->data() && !sm->data()->is_trivial()) {
 		if (stir::Verbosity::get() > 1) std::cout << "applying unnormalisation...";
-		shared_ptr<PETAcquisitionData> sptr_ad(ad.new_acquisition_data());
+                std::shared_ptr<PETAcquisitionData> sptr_ad(ad.new_acquisition_data());
 		sptr_ad->fill(ad);
 		sptr_asm_->unnormalise(*sptr_ad);
 		//sptr_normalisation_->undo(*sptr_ad->data(), 0, 1);


### PR DESCRIPTION
We now use std::shared_ptr for SIRF objects and stir::shared_ptr for STIR objects. Normally they are the same, but that isn't guaranteed.

In the previous code, there was a mix of usages, which was never tested as SIRF was only ever compiled with stir::shared_ptr=std::shared_ptr.

Testing by compiling with a STIR version with `STIR_USE_BOOST_SHARED_PTR=ON`.

Fixes #1000