### PR TITLE
Fix Call to AffineTransformation Constructor

### DIFF
--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -1331,7 +1331,7 @@ class AffineTransformation(_Transformation):
                 isinstance(src2, numpy.ndarray):
             self.handle = pyreg.\
                 cReg_AffineTransformation_construct_from_trans_and_euler(
-                    src1.ctypes.data, src1.ctypes.data)
+                    src1.ctypes.data, src2.ctypes.data)
         else:
             raise error("""AffineTransformation accepts no args, filename,
                         4x4 array or translation with quaternion.""")

--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -23,7 +23,7 @@ import abc
 import sys
 import inspect
 
-from sirf.Utilities import error, check_status, try_calling
+from sirf.Utilities import error, check_status, try_calling, format_numpy_array_for_setter
 from sirf import SIRF
 import pyiutilities as pyiutil
 import pyreg
@@ -1312,6 +1312,7 @@ class AffineTransformation(_Transformation):
         elif isinstance(src1, str):
             self.handle = pyreg.cReg_objectFromFile(self.name, src1)
         elif isinstance(src1, numpy.ndarray) and src2 is None:
+            src1 = format_numpy_array_for_setter(src1)
             if src1.shape != (4, 4):
                 raise AssertionError()
             # Need to transpose relative to MATLAB
@@ -1324,11 +1325,14 @@ class AffineTransformation(_Transformation):
                         trans.ctypes.data)
         elif isinstance(src1, numpy.ndarray) and src2 is not None and \
                 isinstance(src2, Quaternion):
+            src1 = format_numpy_array_for_setter(src1)
             self.handle = pyreg.\
                 cReg_AffineTransformation_construct_from_trans_and_quaternion(
                     src1.ctypes.data, src2.handle)
         elif isinstance(src1, numpy.ndarray) and \
                 isinstance(src2, numpy.ndarray):
+            src1 = format_numpy_array_for_setter(src1)
+            src2 = format_numpy_array_for_setter(src2)
             self.handle = pyreg.\
                 cReg_AffineTransformation_construct_from_trans_and_euler(
                     src1.ctypes.data, src2.ctypes.data)

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -244,6 +244,19 @@ def show_3D_array\
 
     return 0
 
+def format_numpy_array_for_setter(data, dtype_to_pass=numpy.float32):
+
+    if not isinstance(data, numpy.ndarray):
+        raise error('Wrong input format.' + \
+            ' Should be numpy.ndarray. Got {}'.format(type(data)))
+
+    if data.dtype != dtype_to_pass:
+            data = data.astype(dtype_to_pass)
+
+    if not data.flags['C_CONTIGUOUS']:
+        data = numpy.ascontiguousarray(data)
+
+    return data
 
 def check_tolerance(expected, actual, abstol=0, reltol=2e-3):
     '''


### PR DESCRIPTION
Fixes erroneous use of arguments in constructor of Python `AffineTransformation`.
Currently the user has to make sure that numpy arrays are of type `numpy.float32` for them to be passed to the C++ layer correctly.

- Made sure that the correct arrays are passed in the Python `AffineTransformation` constructor from translation and Euler angles.
- Added method `format_numpy_array_for_setter` to utilities to make sure that the arrays are passed as default `numpy.float32` or another type specified. Currently used in `AffineTransformation` constructor only.