### PR TITLE
Implemented workaround enabling new Gadgetron to read old ISMRMRD acquisition data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## v3.x.x
 
+* MR Geometry
+  - fixed GadgetronImagesVector::reorient() to only consider slice index 
+  and ignore dimensions such as contrast, repetition etc.
+
 * PET/STIR
   - (C++) Replaced where possible returning `stir::Succeeded::no` with throwing exception.
   - (C++) Fixed a bug in `PETAcquisitionDataInMemory::norm`.

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1036,15 +1036,20 @@ GadgetronImagesVector::sort()
 	for (int i = 0; i < ni; i++) {
       ImageWrap& iw = image_wrap(i);
       ISMRMRD::ImageHeader& head = iw.head();
-		t[0] = head.contrast;
-        t[1] = head.repetition;
-        // Calculate the projection of the position in the slice direction
-        t[2] = -( head.position[0] * head.slice_dir[0] +
+		// It is crucial to sort the images first by their projection onto the slice direction
+        // and only then consider other dimensions.
+        // In the function this->reorient() the computation of the position of the 2D slices
+        // requires them to be ordered with respect to their projection onto the slice direction to
+        // ensure that they are located next to each other.
+        t[0] = -( head.position[0] * head.slice_dir[0] +
                 head.position[1] * head.slice_dir[1]   +
                 head.position[2] * head.slice_dir[2]   );
+        t[1] = head.contrast;
+        t[2] = head.repetition;
+
 		vt.push_back(t);
 #ifndef NDEBUG
-        std::cout << "Before sorting. Image " << i << "/" << ni <<  ", Contrast: " << t[0] << ", Repetition: " << t[1] << ", Projection: " << t[2] << "\n";
+        std::cout << "Before sorting. Image " << i << "/" << ni <<  ", Projection: " << t[0] << ", Contrast: " << t[1] << ", Repetition: " << t[2] << "\n";
 #endif
 	}
 
@@ -1064,13 +1069,15 @@ GadgetronImagesVector::sort()
     for (int i = 0; i < ni; i++) {
       ImageWrap& iw = image_wrap(i);
       ISMRMRD::ImageHeader& head = iw.head();
-		t[0] = head.contrast;
-        t[1] = head.repetition;
-        // Calculate the projection of the position in the slice direction
-        t[2] = head.position[0] * head.slice_dir[0] +
+		// Calculate the projection of the position in the slice direction
+        t[0] = head.position[0] * head.slice_dir[0] +
                head.position[1] * head.slice_dir[1] +
                head.position[2] * head.slice_dir[2];
-        std::cout << "Image " << i << "/" << ni <<  ", Contrast: " << t[0] << ", Repetition: " << t[1] << ", Projection: " << t[2] << "\n";
+        t[1] = head.contrast;
+        t[2] = head.repetition;
+        
+        std::cout << "Image " << i << "/" << ni <<  ", Projection: " << t[0] << ", Contrast: " << t[1] << ", Repetition: " << t[2] << "\n";
+
 	}
 #endif
 }
@@ -1564,6 +1571,14 @@ void GadgetronImagesVector::reorient(const VoxelisedGeometricalInfo3D &geom_info
     if (!this->sorted())
         this->sort();
 
+    uint16_t number_slices = 0;
+
+    for (unsigned im=1; im<number(); ++im) {
+        ISMRMRD::ImageHeader &ih = image_wrap(im).head();
+        number_slices = (ih.slice > number_slices) ? ih.slice : number_slices; 
+    }
+    number_slices += 1; // account for starting counting at zero.
+
     // loop over all images in stack
     for (unsigned im=0; im<number(); ++im) {
         // Get image header
@@ -1580,16 +1595,31 @@ void GadgetronImagesVector::reorient(const VoxelisedGeometricalInfo3D &geom_info
         // FOV
         auto spacing = geom_info_out.get_spacing();
         auto size = geom_info_out.get_size();
-        for(unsigned i=0; i<3; ++i)
+        
+        // Read and phase FOV are matrix-size * voxel size
+        for(unsigned i=0; i<2; ++i)
             ih.field_of_view[i] = spacing[i] * size[i];
-
+        // 2D slices should only have the slice width as a FOV along slice encoding
+        // for 3D number_slices = 1 and no correction is necessary
+        ih.field_of_view[2] = spacing[2] * size[2] / number_slices; 
+        
         // Position
         auto offset = geom_info_out.get_offset();
         for (unsigned i=0; i<3; ++i)
+        {
             ih.position[i] = offset[i]
                     + direction[i][0] * (ih.field_of_view[0] / 2.0f)
                     + direction[i][1] * (ih.field_of_view[1] / 2.0f)
-                    + direction[i][2] * float(im) * geom_info_out.get_spacing()[2];
+                    + direction[i][2] * (ih.field_of_view[2] / 2.0f); // for 2D stacks this is half the slice thickness
+                     
+            // For 2D stacks the position is the position of the first slice plus the slice number in the slice direction.
+            // However, temporally subsequently acquired slices are usually not next to each other in space
+            // but at a distance to ensure relaxation of the magnetisation.
+            // this->sort() called above sorts the images first by the projection onto the slice direction.
+            // Hence (im % number_slices) gives the geometrical order of slices while
+            // using ih.slice to iterate over slices would give them in order of acquisition time instead. 
+            ih.position[i] += direction[i][2] * (im % number_slices) * geom_info_out.get_spacing()[2]; 
+        }
     }
 
     // set up geom info
@@ -1625,8 +1655,6 @@ GadgetronImagesVector::set_up_geom_info()
     if (!this->sorted())
         this->sort();
 
-    bool is_2d_stack = number()>1;
-
     // Patient position not necessary as read, phase and slice directions
     // are already in patient coordinates
 #if 0
@@ -1648,29 +1676,47 @@ GadgetronImagesVector::set_up_geom_info()
     }
 
     // Check that the read, phase and slice directions are constant
+    uint16_t number_slices = ih1.slice; 
+
     for (unsigned im=1; im<number(); ++im) {
         ISMRMRD::ImageHeader &ih = image_wrap(im).head();
+        
+        // record which is the largest slice index
+        // this allows to differentiate between slice number and this->number() as the
+        // latter also includes different contrasts, phases, repetitions etc. that have
+        // no geometrical meaning
+        number_slices = (ih.slice > number_slices) ? ih.slice : number_slices; 
+
         if (!(are_vectors_equal(ih1.read_dir,ih.read_dir) && are_vectors_equal(ih1.phase_dir,ih.phase_dir) && are_vectors_equal(ih1.slice_dir,ih.slice_dir))) {
             std::cout << "\nGadgetronImagesVector::set_up_geom_info(): read_dir, phase_dir and slice_dir should be constant over slices.\n";
             return;
         }
     }
+    number_slices += 1; // we start counting at 0
 
     // Size
     // For the z-direction.
     // If it's a 3d image, matrix_size[2] == num voxels
-    // If it's a 2d image, matrix_size[2] == 1, and number of slices is given by this->number()
+    // If it's a 2d image, matrix_size[2] == 1, and number of slices is given by number_slices.
+    // We will check below that if 3D data is present, slices are not repeated as we do not yet cover this case.
+    // Luckily this is usually not happening.
     VoxelisedGeometricalInfo3D::Size size;
     for(unsigned i=0; i<3; ++i)
         size[i] = ih1.matrix_size[i];
-    // If it's a stack of 2d images.
-    if (is_2d_stack)
-        size[2] = this->number();
-
+    
     // Spacing
+    //for 2D case: size[2] = 1 and ih1.field_of_view[2] = excited slice thickness
     VoxelisedGeometricalInfo3D::Spacing spacing;
     for(unsigned i=0; i<3; ++i)
-        spacing[i] = ih1.field_of_view[i] / size[i];
+        spacing[i] = ih1.field_of_view[i] / size[i]; 
+
+    bool const is_2d_stack = (number_slices > 1) && (size[2] == 1);
+
+    if( (number_slices > 1) && (size[2] > 1))
+        throw LocalisedException("You try to set up the geometry information for 3D data that contains multiple slices. This special case is unavailable." , __FILE__, __LINE__);
+
+    if( is_2d_stack )        
+            size[2] = number_slices;
 
     // If there are more than 1 slices, then take the size of the voxel
     // in the z-direction to be the distance between voxel centres (this
@@ -1679,6 +1725,15 @@ GadgetronImagesVector::set_up_geom_info()
 
         // Calculate the spacing!
         ISMRMRD::ImageHeader &ih2 = image_wrap(1).head();
+
+        const float tolerance_mm = 0.01f;
+        if( std::abs(spacing[2] - get_slice_spacing(ih1, ih2)) > tolerance_mm )
+        {
+            std::cout << "\nGadgetronImagesVector::set_up_geom_info(). "
+                        "Warning, you set up geometry for slices whose width is not their distance."
+                        "This setup does probably not account for overlaps or gaps between slices.\n";
+        }
+        // just making sure they are the same, as opposed to "up to tolerance"
         spacing[2] = get_slice_spacing(ih1, ih2);
 
         // Check: Loop over all images, and check that spacing is more-or-less constant
@@ -1698,7 +1753,7 @@ GadgetronImagesVector::set_up_geom_info()
 
     // Make sure we're looking at the first image
     ih1 = image_wrap( 0 ).head();
-
+    
     // Direction
     VoxelisedGeometricalInfo3D::DirectionMatrix direction;
     for (unsigned axis=0; axis<3; ++axis) {
@@ -1712,15 +1767,8 @@ GadgetronImagesVector::set_up_geom_info()
     for (unsigned i=0; i<3; ++i)
         offset[i] = ih1.position[i]
                 - direction[i][0] * (ih1.field_of_view[0] / 2.0f)
-                - direction[i][1] * (ih1.field_of_view[1] / 2.0f);
-
-    // TODO this isn't perfect
-    if (!is_2d_stack && size[2]>1) {
-        std::cout << "\nGadgetronImagesVector::set_up_geom_info(). "
-                     "Warning, we think we're ~half a voxel out in the 3D case.\n";
-        for (unsigned i=0; i<3; ++i)
-            offset[i] += ih1.slice_dir[i] * (ih1.field_of_view[2] / 2.0f);
-    }
+                - direction[i][1] * (ih1.field_of_view[1] / 2.0f)
+                - direction[i][2] * (ih1.field_of_view[2] / 2.0f);
 
     // Initialise the geom info shared pointer
     this->set_geom_info(std::make_shared<VoxelisedGeometricalInfo3D>

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -114,9 +114,11 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 			int va = std::stoi(xml.substr(i + 9, j - i - 9));
 			int v = ISMRMRD_XMLHDR_VERSION;
 			if (va > v) {
-				str << "ERROR: ISMRMRD header version (" << v
-					<< ") is older than the acquisitions header version ("
-					<< va << "), terminating...";
+				str << "Input acquisition file was written in with "
+				<< "ISMRMRD XML version "<< va 
+				<< ", but the version of ISMRMRD used presently by SIRF "
+				<< "supports XML version " << v 
+				<< " or less only, terminating...";
 				THROW(str.str());
 			}
 			else if (va < v) {

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -29,7 +29,7 @@ limitations under the License.
 \author Johannes Mayer
 \author SyneRBI
 */
-#include <algorithm> 
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <sstream>
@@ -114,11 +114,10 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 			int va = std::stoi(xml.substr(i + 9, j - i - 9));
 			int v = ISMRMRD_XMLHDR_VERSION;
 			if (va > v) {
-				str << "ERROR: ISMRMRD header version (" << v 
+				str << "ERROR: ISMRMRD header version (" << v
 					<< ") is older than the acquisitions header version ("
 					<< va << "), terminating...";
 				THROW(str.str());
-//				THROW("ERROR: ISMRMRD version too old, terminating...");
 			}
 			else if (va < v) {
 				std::cout << "WARNING: ";

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -107,6 +107,13 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 		uint32_t num_acquis = d.getNumberOfAcquisitions();
 		mtx.unlock();
 
+		std::string xml = this->acqs_info_.c_str();
+		size_t i = xml.find("<version>");
+		if (i != std::string::npos) {
+			size_t j = xml.find("</version>");
+			this->acqs_info_ = xml.substr(0, i) + xml.substr(j + 10);
+		}
+
 		for( uint32_t i_acqu=0; i_acqu<num_acquis; i_acqu++)
 		{
 			if( verbose )

--- a/src/xGadgetron/cGadgetron/tests/mrtests.cpp
+++ b/src/xGadgetron/cGadgetron/tests/mrtests.cpp
@@ -36,13 +36,12 @@ limitations under the License.
 
 #include <ismrmrd/xml.h>
 
-#include "sirf/Gadgetron/chain_lib.h"
-
 #include "sirf/common/DataContainer.h"
 #include "sirf/common/getenv.h"
+
+#include "sirf/Gadgetron/chain_lib.h"
 #include "sirf/Gadgetron/gadgetron_data_containers.h"
 #include "sirf/Gadgetron/gadgetron_x.h"
-
 #include "sirf/Gadgetron/FourierEncoding.h"
 #include "sirf/Gadgetron/TrajectoryPreparation.h"
 
@@ -122,6 +121,8 @@ bool test_ISMRMRDImageData_from_MRAcquisitionData(MRAcquisitionData& av)
         MatrixSize rawdata_recon_matrix = rec_space.matrixSize;
         FieldOfView_mm rawdata_recon_FOV = rec_space.fieldOfView_mm;
 
+        float const tolerance_mm = 0.1;        
+
         for(int i=0; i<iv.number(); ++i)
         {
             CFImage* const ptr_img = (CFImage*)(iv.sptr_image_wrap(i)->ptr_image());            
@@ -130,16 +131,72 @@ bool test_ISMRMRDImageData_from_MRAcquisitionData(MRAcquisitionData& av)
             test_successful *= (ptr_img->getMatrixSizeY() == rawdata_recon_matrix.y);
             test_successful *= (ptr_img->getMatrixSizeZ() == rawdata_recon_matrix.z);
 
-        	test_successful *= (ptr_img->getFieldOfViewX() == rawdata_recon_FOV.x);
-            test_successful *= (ptr_img->getFieldOfViewY() == rawdata_recon_FOV.y);
-            test_successful *= (ptr_img->getFieldOfViewZ() == rawdata_recon_FOV.z);
+        	test_successful *= (std::abs(ptr_img->getFieldOfViewX() - rawdata_recon_FOV.x) < tolerance_mm);
+            test_successful *= (std::abs(ptr_img->getFieldOfViewY() - rawdata_recon_FOV.y) < tolerance_mm);
+            test_successful *= (std::abs(ptr_img->getFieldOfViewZ() - rawdata_recon_FOV.z) < tolerance_mm);
         }
 
-        if(test_successful)
-            return test_successful;
-        else{
-            throw std::runtime_error("The test for images from acquisition data failed.");                
+        return test_successful;
+        
+
+    }
+    catch( std::runtime_error const &e)
+    {
+        std::cout << "Exception caught " <<__FUNCTION__ <<" .!" <<std::endl;
+        std::cout << e.what() << std::endl;
+        throw;
+    }
+}
+
+bool test_ISMRMRDImageData_reorienting(MRAcquisitionData& av)
+{
+    try
+    {
+        using namespace ISMRMRD;
+
+        std::cout << "Running test " << __FUNCTION__ << std::endl;
+
+        GadgetronImagesVector iv(av);
+        std::shared_ptr<const VoxelisedGeometricalInfo3D > sptr_geom_info = iv.get_geom_info_sptr();
+
+        VoxelisedGeometricalInfo3D::Size input_size = sptr_geom_info->get_size();
+
+        std::default_random_engine generator;
+        generator.seed(100000); // 
+        float const maximum_random_range = 100.f;
+        std::uniform_real_distribution<float> distribution(0, maximum_random_range);
+
+        float const rand_angle = distribution(generator);
+        std::cout << "Rotating by an angle of : " << rand_angle << std::endl;
+        VoxelisedGeometricalInfo3D::DirectionMatrix random_rotation{
+            std::cos(rand_angle), -std::sin(rand_angle), 0,
+            std::sin(rand_angle),  std::cos(rand_angle), 0,
+            0, 0, 1};
+
+        VoxelisedGeometricalInfo3D::DirectionMatrix direction = sptr_geom_info->get_direction();
+        VoxelisedGeometricalInfo3D::DirectionMatrix rotated_direction = direction;
+        
+        for(int i=0; i<3; ++i)
+        for(int j=0; j<3; ++j)
+        {   
+            rotated_direction[i][j] = 0.0;
+
+            for(int k=0; k<3; ++k)
+            for(int l=0; l<3; ++l)
+                rotated_direction[i][j] += random_rotation[i][k]*direction[k][l]*random_rotation[j][l];
+
         }
+        VoxelisedGeometricalInfo3D::Offset offset{distribution(generator),distribution(generator),distribution(generator)};
+        VoxelisedGeometricalInfo3D::Spacing spacing{distribution(generator),distribution(generator),distribution(generator)};                    
+
+        VoxelisedGeometricalInfo3D random_new_geometry(offset, spacing, input_size, rotated_direction);
+
+        if(!iv.can_reorient(*sptr_geom_info, random_new_geometry, false))
+            throw std::runtime_error("You can not perform this arbitrary reorienting.");
+
+        iv.reorient(random_new_geometry);
+        
+        return true;
 
     }
     catch( std::runtime_error const &e)
@@ -600,12 +657,11 @@ int main ( int argc, char* argv[])
 
         bool ok = true;
 
-        
-
         ok *= test_get_kspace_order(av);
         ok *= test_get_subset(av);
 
         ok *= test_ISMRMRDImageData_from_MRAcquisitionData(av);
+        ok *= test_ISMRMRDImageData_reorienting(av);
 
         ok *= test_CoilSensitivitiesVector_calculate(av);
         ok *= test_CoilSensitivitiesVector_get_csm_as_cfimage(av);

--- a/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
+++ b/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
@@ -30,11 +30,8 @@ def test_main(rec=False, verb=False, throw=True):
     rawdata = preprocess_acquisition_data(rawdata)
     rawdata.sort()
     
-    
-
     imgdata = ImageData()
     imgdata.from_acquisition_data(rawdata)
-    
         
     acq_model = AcquisitionModel()
     acq_model.set_up(rawdata, imgdata)


### PR DESCRIPTION
Recent versions of Gadgetron fail to read ISMRMRD acquisition data generated by old ISMRMRD because of the line
```
<version>3</version>
```
in the acquisition data header XML.

This workaround simply makes method `MRAcquisitionData::read` ignore this line.