### PR TITLE
Ignore User-Defined K-Space Dimensions

### DIFF
--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -867,7 +867,7 @@ KSpaceSubset::TagType KSpaceSubset::get_tag_from_img(const CFImage& img)
     tag[6] = 0; //segments area always zero
 
     for(int i=0; i<ISMRMRD::ISMRMRD_Constants::ISMRMRD_USER_INTS; ++i)
-        tag[7+i] = img.getUserInt(i);
+        tag[7+i] = 0; //img.getUserInt(i);
 
     return tag;
 }
@@ -885,7 +885,7 @@ KSpaceSubset::TagType KSpaceSubset::get_tag_from_acquisition(ISMRMRD::Acquisitio
     tag[6] = 0; //acq.idx().segment;
 
     for(int i=7; i<tag.size(); ++i)
-        tag[i]=acq.idx().user[i];
+        tag[i]= 0; //acq.idx().user[i];
 
     return tag;
 }


### PR DESCRIPTION
Fixes #1036.

Previously, extra dimensions of the k-space were ignored, but images were still allowed to carry this extra index.
During forward-projection when comparing whether the destination container was consistent with the image to be forward-projected this index comparison caused errors.

This PR now ignores all user-defined extra dimensions for both acquisitions and images and makes this comparison consistent.



