### PR TITLE
Ensuring an empty target header before AcquisitionsInfo::deserialize()

### DIFF
--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -118,7 +118,9 @@ namespace sirf {
 		void deserialize() const
 		{
 			if (!this->empty())
+			{	header_ = ISMRMRD::IsmrmrdHeader();
 				ISMRMRD::deserialize(data_.c_str(), header_);
+			}
             have_header_ = true;
 		}
 		std::string data_;


### PR DESCRIPTION
Fixes #1049 