### PR TITLE
minor changes to reduce conversion compiler warnings

### DIFF
--- a/src/Registration/cReg/include/sirf/Reg/Parser.h
+++ b/src/Registration/cReg/include/sirf/Reg/Parser.h
@@ -214,7 +214,7 @@ public:
     std::string get_keyword(std::string &line)
     {
         // get index of the ":="
-        int index_end = line.find(":=");
+        auto index_end = line.find(":=");
 
         std::string keyword = line.substr(0, index_end);
 

--- a/src/Registration/cReg/include/sirf/Reg/ParserKey.h
+++ b/src/Registration/cReg/include/sirf/Reg/ParserKey.h
@@ -106,8 +106,8 @@ protected:
     {
         // Start index is always to right of the ":="
         // End index is up to ","
-        int index_start = line.find(":=") + 2;
-        int index_end   = line.find(",");
+        auto index_start = line.find(":=") + 2;
+        auto index_end   = line.find(",");
 
         // For subsequent arguments
         for (int i=0; i<arg_num; i++) {
@@ -137,7 +137,7 @@ protected:
     void get_argument(const std::string &line, const int arg_num, int &arg          ) const { arg = std::stoi(get_arg_as_string(line, arg_num));  }
 
     /// Get argument - unsigned int
-    void get_argument(const std::string &line, const int arg_num, unsigned int &arg ) const { arg = std::stoll(get_arg_as_string(line, arg_num)); }
+    void get_argument(const std::string &line, const int arg_num, unsigned int &arg ) const { arg = static_cast<unsigned>(std::stoul(get_arg_as_string(line, arg_num))); }
 
     /// Get argument - float
     void get_argument(const std::string &line, const int arg_num, float &arg        ) const { arg = std::stof(get_arg_as_string(line, arg_num));  }

--- a/src/common/include/sirf/common/GeometricalInfo.h
+++ b/src/common/include/sirf/common/GeometricalInfo.h
@@ -90,8 +90,8 @@ public:
 	virtual bool operator==(const GeometricalInfo<num_dimensions, num_dimensions>& gi) const
 	{
 		const VoxelisedGeometricalInfo& vgi = (const VoxelisedGeometricalInfo&)gi;
-		float eps = 0.01;
-		float delta = 0.1;
+		const float eps = 0.01F;
+		const float delta = 0.1F;
 		return
 			near_(_offset, vgi.get_offset(), eps) &&
 			near_(_spacing, vgi.get_spacing(), eps) &&

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -815,7 +815,7 @@ sirf::cSTIR_setFBP2DParameter(DataHandle* hp, const char* name, const DataHandle
 		recon.set_input(acq_data);
 	}
 	else if (sirf::iequals(name, "zoom")) {
-		double zoom = dataFromHandle<float>(hv);
+		float zoom = dataFromHandle<float>(hv);
 		recon.set_zoom(zoom);
 		recon.cancel_setup();
 	}
@@ -825,7 +825,7 @@ sirf::cSTIR_setFBP2DParameter(DataHandle* hp, const char* name, const DataHandle
 		recon.cancel_setup();
 	}
 	else if (sirf::iequals(name, "alpha")) {
-		double alpha = dataFromHandle<float>(hv);
+		float alpha = dataFromHandle<float>(hv);
 		recon.set_alpha_ramp(alpha);
 	}
 	else if (sirf::iequals(name, "fc")) {


### PR DESCRIPTION
Visual Studio gives quite a few warnings on conversions. After this there are a few less.