### PR TITLE
work around problem finding HDF5 with older CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,17 @@ set(SHARE_DIR ${CMAKE_INSTALL_PREFIX}/share/SIRF-${VERSION_MAJOR}.${VERSION_MINO
 configure_file("cmake/version.h.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake/include/sirf/common/version.h")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/include/sirf/common/version.h" DESTINATION "${CMAKE_INSTALL_PREFIX}/include/sirf/common/")
 
+if (CMAKE_VERSION VERSION_LESS 3.21.0)
+  # Possibly superfluous finding of HDF5, looking for both C and CXX libraries
+  # This is an attempt to overcome https://gitlab.kitware.com/cmake/cmake/-/issues/20909
+  # We will try to find ISMRMRD and STIR later. The former needs HDF C, the latter HDF5 CXX.
+  # By looking for both first, CMake will populate targets for HDF5 for both C and CXX.
+  #
+  # Note that this is slightly dangerous if there are multiple versions of HDF5 on the system.
+  # ISMRMRD and STIR might be looking for a specific version while the statement below doesn't.
+  find_package(HDF5 COMPONENTS C CXX QUIET)
+endif()
+
 ADD_SUBDIRECTORY(src)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/setup.py.cmake")


### PR DESCRIPTION
ISMRMRD and STIR can use HDF5, but ISMRMRD needs C and STIR needs C++. This creates a conflict on older CMake, see https://gitlab.kitware.com/cmake/cmake/-/issues/20909

Until recently STIR prevented a conflict, but this will change now, as it actually broke STIR import as STIRConfig.cmake was just looking for the C HDF5 libraries. See https://github.com/UCL/STIR/blob/476947105233d5aa0336e16f1a437a43bca47894/src/cmake/STIRConfig.cmake.in#L72