### PR TITLE
Ensure Python int arrays exchanged with C++ contain compatible (sizeof(int)-bytes) integers

### DIFF
--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -23,7 +23,8 @@ import abc
 import sys
 import inspect
 
-from sirf.Utilities import error, check_status, try_calling, format_numpy_array_for_setter
+from sirf.Utilities import error, check_status, try_calling, \
+     cpp_int_dtype, cpp_int_array, format_numpy_array_for_setter
 from sirf import SIRF
 import pyiutilities as pyiutil
 import pyreg
@@ -291,7 +292,7 @@ class NiftiImageData(SIRF.ImageData):
         """
         if self.handle is None:
             raise AssertionError()
-        dim = numpy.ndarray((8,), dtype=numpy.int32)
+        dim = numpy.ndarray((8,), dtype=cpp_int_dtype())
         try_calling(pyreg.cReg_NiftiImageData_get_dimensions(
             self.handle, dim.ctypes.data))
         return dim
@@ -409,8 +410,8 @@ class NiftiImageData(SIRF.ImageData):
         # Fill in any missing indices with -1's
         min_.extend([-1] * (7-len(min_)))
         max_.extend([-1] * (7-len(max_)))
-        min_np = numpy.array(min_, dtype=numpy.int32)
-        max_np = numpy.array(max_, dtype=numpy.int32)
+        min_np = numpy.array(min_, dtype=cpp_int_dtype())
+        max_np = numpy.array(max_, dtype=cpp_int_dtype())
         try_calling(pyreg.cReg_NiftiImageData_crop(
             self.handle, min_np.ctypes.data, max_np.ctypes.data))
 
@@ -431,8 +432,8 @@ class NiftiImageData(SIRF.ImageData):
         # Fill in any missing indices with -1's
         min_.extend([-1] * (7-len(min_)))
         max_.extend([-1] * (7-len(max_)))
-        min_np = numpy.array(min_, dtype=numpy.int32)
-        max_np = numpy.array(max_, dtype=numpy.int32)
+        min_np = numpy.array(min_, dtype=cpp_int_dtype())
+        max_np = numpy.array(max_, dtype=cpp_int_dtype())
         try_calling(pyreg.cReg_NiftiImageData_pad(
             self.handle, min_np.ctypes.data, max_np.ctypes.data, float(val)))
 

--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -24,7 +24,7 @@ import sys
 import inspect
 
 from sirf.Utilities import error, check_status, try_calling, \
-     cpp_int_dtype, cpp_int_array, format_numpy_array_for_setter
+     cpp_int_dtype, format_numpy_array_for_setter
 from sirf import SIRF
 import pyiutilities as pyiutil
 import pyreg

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -31,7 +31,7 @@ import sys
 import warnings
 
 from sirf.Utilities import assert_validity, assert_validities, \
-     cpp_int_dtype, cpp_int_array, check_status, try_calling, error
+     cpp_int_dtype, check_status, try_calling, error
 import pyiutilities as pyiutil
 import sirf.pysirf as pysirf
 

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -30,7 +30,8 @@ except:
 import sys
 import warnings
 
-from sirf.Utilities import assert_validity, assert_validities, check_status, try_calling, error
+from sirf.Utilities import assert_validity, assert_validities, \
+     cpp_int_dtype, cpp_int_array, check_status, try_calling, error
 import pyiutilities as pyiutil
 import sirf.pysirf as pysirf
 
@@ -775,7 +776,7 @@ class GeometricalInfo(object):
     
     def get_size(self):
         """Size is the number of voxels in each dimension."""
-        arr = numpy.ndarray((3,), dtype = numpy.int32)
+        arr = numpy.ndarray((3,), dtype = cpp_int_dtype())
         try_calling (pysirf.cSIRF_GeomInfo_get_size(self.handle, arr.ctypes.data))
         return tuple(arr)
 

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -32,18 +32,18 @@ RE_PYEXT = re.compile(r"\.(py[co]?)$")
 
 
 def cpp_int_bits():
-    """Returns the number of bits in a C++ integer"""
+    """Returns the number of bits in a C++ integer."""
     return pyiutil.intBits()
 
 
 def cpp_int_dtype():
-    """Returns numpy dtype corresponding to a C++ int"""
+    """Returns numpy dtype corresponding to a C++ int."""
     dt = 'int%s' % cpp_int_bits()
     return numpy.dtype(dt)
 
 
 def cpp_int_array(v):
-    """Converts the input into numpy.ndarray compatible with C++ int array"""
+    """Converts the input into numpy.ndarray compatible with C++ int array."""
     dt = numpy.dtype('int%s' % cpp_int_bits())
     if not isinstance(v, numpy.ndarray):
         v = numpy.array(v, dtype=dt)

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -32,18 +32,18 @@ RE_PYEXT = re.compile(r"\.(py[co]?)$")
 
 
 def cpp_int_bits():
-    '''Returns the number of bits in C++ integer'''
+    """Returns the number of bits in a C++ integer"""
     return pyiutil.intBits()
 
 
 def cpp_int_dtype():
-    '''Returns numpy dtype corresponding to C++ int'''
+    """Returns numpy dtype corresponding to a C++ int"""
     dt = 'int%s' % cpp_int_bits()
     return numpy.dtype(dt)
 
 
 def cpp_int_array(v):
-    '''Converts the input into numpy.ndarray compatible with C++ int array'''
+    """Converts the input into numpy.ndarray compatible with C++ int array"""
     dt = numpy.dtype('int%s' % cpp_int_bits())
     if not isinstance(v, numpy.ndarray):
         v = numpy.array(v, dtype=dt)

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -31,12 +31,12 @@ __license__ = __licence__
 RE_PYEXT = re.compile(r"\.(py[co]?)$")
 
 
-def cpp_int_bytes():
-    return pyiutil.intBytes()
+def cpp_int_bits():
+    return pyiutil.intBits()
 
 
 def cpp_int_array(v):
-    dt = numpy.dtype('int%s' % cpp_int_bytes())
+    dt = numpy.dtype('int%s' % cpp_int_bits())
     if not isinstance(v, numpy.ndarray):
         v = numpy.array(v, dtype=dt)
     elif dt != v.dtype:

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -31,6 +31,21 @@ __license__ = __licence__
 RE_PYEXT = re.compile(r"\.(py[co]?)$")
 
 
+def cpp_int_bytes():
+    return pyiutil.intBytes()
+
+
+def cpp_int_array(v):
+    dt = numpy.dtype('int%s' % cpp_int_bytes())
+    if not isinstance(v, numpy.ndarray):
+        v = numpy.array(v, dtype=dt)
+    elif dt != v.dtype:
+        v = v.astype(dt)
+    if not v.flags['C_CONTIGUOUS']:
+        v = numpy.ascontiguousarray(v)
+    return v
+
+
 @deprecated(
     deprecated_in="2.0.0", removed_in="4.0", current_version=sirf.__version__,
     details="use examples_data_path() instead")

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -32,10 +32,18 @@ RE_PYEXT = re.compile(r"\.(py[co]?)$")
 
 
 def cpp_int_bits():
+    '''Returns the number of bits in C++ integer'''
     return pyiutil.intBits()
 
 
+def cpp_int_dtype():
+    '''Returns numpy dtype corresponding to C++ int'''
+    dt = 'int%s' % cpp_int_bits()
+    return numpy.dtype(dt)
+
+
 def cpp_int_array(v):
+    '''Converts the input into numpy.ndarray compatible with C++ int array'''
     dt = numpy.dtype('int%s' % cpp_int_bits())
     if not isinstance(v, numpy.ndarray):
         v = numpy.array(v, dtype=dt)

--- a/src/iUtilities/include/sirf/iUtilities/iutilities.h
+++ b/src/iUtilities/include/sirf/iUtilities/iutilities.h
@@ -24,6 +24,7 @@ limitations under the License.
 #ifndef IUTILITIES_FOR_MATLAB
 extern "C" {
 #endif
+	int intBytes();
 	void* newDataHandle();
 	void deleteDataHandle(void* ptr);
 	void* charDataHandle(const char* s);

--- a/src/iUtilities/include/sirf/iUtilities/iutilities.h
+++ b/src/iUtilities/include/sirf/iUtilities/iutilities.h
@@ -24,7 +24,7 @@ limitations under the License.
 #ifndef IUTILITIES_FOR_MATLAB
 extern "C" {
 #endif
-	int intBytes();
+	int intBits();
 	void* newDataHandle();
 	void deleteDataHandle(void* ptr);
 	void* charDataHandle(const char* s);

--- a/src/iUtilities/iutilities.cpp
+++ b/src/iUtilities/iutilities.cpp
@@ -36,7 +36,7 @@ Defines C functions handling DataHandle objects.
 
 extern "C" {
 
-	int intBytes()
+	int intBits()
 	{
 		return 8 * sizeof(int);
 	}

--- a/src/iUtilities/iutilities.cpp
+++ b/src/iUtilities/iutilities.cpp
@@ -36,6 +36,11 @@ Defines C functions handling DataHandle objects.
 
 extern "C" {
 
+	int intBytes()
+	{
+		return 8 * sizeof(int);
+	}
+
 	void* newDataHandle() // C constructor
 	{
 		return (void*)new DataHandle;

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -37,7 +37,7 @@ from deprecation import deprecated
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
      try_calling, assert_validity, assert_validities, label_and_name, \
      name_and_parameters, parse_arglist, \
-     cpp_int_bytes, cpp_int_array, \
+     cpp_int_bits, cpp_int_array, \
      examples_data_path, existing_filepath, \
      pTest, RE_PYEXT
 import sirf
@@ -406,7 +406,7 @@ class ImageData(SIRF.ImageData):
         if self.number() < 1:
             return 0
         assert self.handle is not None
-        dt = 'int%s' % cpp_int_bytes()
+        dt = 'int%s' % cpp_int_bits()
         dim = numpy.ndarray((4,), dtype=numpy.dtype(dt))
 #        dim = numpy.ndarray((4,), dtype = numpy.int32)
         image = Image(self)
@@ -965,7 +965,7 @@ class AcquisitionData(DataContainer):
         assert self.handle is not None
         if self.number() < 1:
             return numpy.zeros((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
-        dt = 'int%s' % cpp_int_bytes()
+        dt = 'int%s' % cpp_int_bits()
         dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype=numpy.dtype(dt))
 #        dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
         hv = pygadgetron.cGT_getAcquisitionDataDimensions\

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -37,6 +37,7 @@ from deprecation import deprecated
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
      try_calling, assert_validity, assert_validities, label_and_name, \
      name_and_parameters, parse_arglist, \
+     cpp_int_bytes, cpp_int_array, \
      examples_data_path, existing_filepath, \
      pTest, RE_PYEXT
 import sirf
@@ -405,7 +406,9 @@ class ImageData(SIRF.ImageData):
         if self.number() < 1:
             return 0
         assert self.handle is not None
-        dim = numpy.ndarray((4,), dtype = numpy.int32)
+        dt = 'int%s' % cpp_int_bytes()
+        dim = numpy.ndarray((4,), dtype=numpy.dtype(dt))
+#        dim = numpy.ndarray((4,), dtype = numpy.int32)
         image = Image(self)
         pygadgetron.cGT_getImageDim(image.handle, dim.ctypes.data)
         nx = dim[0]
@@ -962,7 +965,9 @@ class AcquisitionData(DataContainer):
         assert self.handle is not None
         if self.number() < 1:
             return numpy.zeros((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
-        dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
+        dt = 'int%s' % cpp_int_bytes()
+        dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype=numpy.dtype(dt))
+#        dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
         hv = pygadgetron.cGT_getAcquisitionDataDimensions\
              (self.handle, dim.ctypes.data)
         #nr = pyiutil.intDataFromHandle(hv)

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -925,7 +925,7 @@ class AcquisitionData(DataContainer):
         '''
         assert self.handle is not None
         subset = AcquisitionData()
-        idx = numpy.array(idx, dtype = numpy.int32)
+        idx = numpy.array(idx, dtype = cpp_int_dtype())
         subset.handle = pygadgetron.cGT_getAcquisitionsSubset(self.handle, idx.ctypes.data, idx.size)
         check_status(subset.handle)
         
@@ -962,7 +962,7 @@ class AcquisitionData(DataContainer):
         '''
         assert self.handle is not None
         if self.number() < 1:
-            return numpy.zeros((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
+            return numpy.zeros((MAX_ACQ_DIMENSIONS,), dtype=cpp_int_dtype())
         dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype=cpp_int_dtype())
         hv = pygadgetron.cGT_getAcquisitionDataDimensions\
              (self.handle, dim.ctypes.data)
@@ -994,7 +994,7 @@ class AcquisitionData(DataContainer):
             na = len(rng)
         f = min(rng)
         t = max(rng) + 1
-        info = numpy.ndarray((2,), dtype=numpy.int32)
+        info = numpy.ndarray((2,), dtype=cpp_int_dtype())
         try_calling(pygadgetron.cGT_acquisitionParameterInfo \
                     (self.handle, par, info.ctypes.data))
         n = int(info[1])

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -37,7 +37,7 @@ from deprecation import deprecated
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
      try_calling, assert_validity, assert_validities, label_and_name, \
      name_and_parameters, parse_arglist, \
-     cpp_int_bits, cpp_int_dtype, cpp_int_array, \
+     cpp_int_dtype, cpp_int_array, \
      examples_data_path, existing_filepath, \
      pTest, RE_PYEXT
 import sirf

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -37,7 +37,7 @@ from deprecation import deprecated
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
      try_calling, assert_validity, assert_validities, label_and_name, \
      name_and_parameters, parse_arglist, \
-     cpp_int_bits, cpp_int_array, \
+     cpp_int_bits, cpp_int_dtype, cpp_int_array, \
      examples_data_path, existing_filepath, \
      pTest, RE_PYEXT
 import sirf
@@ -406,9 +406,7 @@ class ImageData(SIRF.ImageData):
         if self.number() < 1:
             return 0
         assert self.handle is not None
-        dt = 'int%s' % cpp_int_bits()
-        dim = numpy.ndarray((4,), dtype=numpy.dtype(dt))
-#        dim = numpy.ndarray((4,), dtype = numpy.int32)
+        dim = numpy.ndarray((4,), dtype=cpp_int_dtype())
         image = Image(self)
         pygadgetron.cGT_getImageDim(image.handle, dim.ctypes.data)
         nx = dim[0]
@@ -965,12 +963,9 @@ class AcquisitionData(DataContainer):
         assert self.handle is not None
         if self.number() < 1:
             return numpy.zeros((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
-        dt = 'int%s' % cpp_int_bits()
-        dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype=numpy.dtype(dt))
-#        dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype = numpy.int32)
+        dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype=cpp_int_dtype())
         hv = pygadgetron.cGT_getAcquisitionDataDimensions\
              (self.handle, dim.ctypes.data)
-        #nr = pyiutil.intDataFromHandle(hv)
         pyiutil.deleteDataHandle(hv)
         dim[2] = numpy.prod(dim[2:])
         return tuple(dim[2::-1])

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -37,7 +37,7 @@ from deprecation import deprecated
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
      try_calling, assert_validity, assert_validities, label_and_name, \
      name_and_parameters, parse_arglist, \
-     cpp_int_dtype, cpp_int_array, \
+     cpp_int_dtype, \
      examples_data_path, existing_filepath, \
      pTest, RE_PYEXT
 import sirf

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -549,7 +549,7 @@ class ImageData(SIRF.ImageData):
             raise error('zoom_image: size should be tuple')
         np_zooms = numpy.asarray(zooms, dtype=numpy.float32)
         np_offsets_in_mm = numpy.asarray(offsets_in_mm, dtype=numpy.float32)
-        np_size = numpy.asarray(size, dtype=numpy.int32)
+        np_size = numpy.asarray(size, dtype=cpp_int_dtype())
 
         try_calling(pystir.cSTIR_ImageData_zoom_image(
             zoomed_im.handle, np_zooms.ctypes.data,

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -34,7 +34,7 @@ from deprecation import deprecated
 
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
      try_calling, assert_validity, \
-     cpp_int_bits, cpp_int_dtype, cpp_int_array, \
+     cpp_int_dtype, cpp_int_array, \
      examples_data_path, existing_filepath, pTest
 from sirf import SIRF
 from sirf.SIRF import DataContainer

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -430,7 +430,9 @@ class ImageData(SIRF.ImageData):
         """Returns image dimensions as a tuple (nz, ny, nx)."""
         if self.handle is None:
             raise AssertionError()
-        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
+        dt = 'int%s' % cpp_int_bytes()
+        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.dtype(dt))
+#        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
         try_calling(
             pystir.cSTIR_getImageDimensions(self.handle, dim.ctypes.data))
         return tuple(dim[:3])  # [::-1])
@@ -980,7 +982,9 @@ class AcquisitionData(DataContainer):
         """
         if self.handle is None:
             raise AssertionError()
-        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
+        dt = 'int%s' % cpp_int_bytes()
+        dim = numpy.ndarray((MAX_ACQ_DIMS,), dtype=numpy.dtype(dt))
+#        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
         try_calling(pystir.cSTIR_getAcquisitionDataDimensions(
             self.handle, dim.ctypes.data))
         dim = dim[:4]

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -33,7 +33,7 @@ from numbers import Integral, Number
 from deprecation import deprecated
 
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
-     try_calling, assert_validity, cpp_int_bytes, cpp_int_array, \
+     try_calling, assert_validity, cpp_int_bits, cpp_int_array, \
      examples_data_path, existing_filepath, pTest
 from sirf import SIRF
 from sirf.SIRF import DataContainer
@@ -430,7 +430,7 @@ class ImageData(SIRF.ImageData):
         """Returns image dimensions as a tuple (nz, ny, nx)."""
         if self.handle is None:
             raise AssertionError()
-        dt = 'int%s' % cpp_int_bytes()
+        dt = 'int%s' % cpp_int_bits()
         dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.dtype(dt))
 #        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
         try_calling(
@@ -982,7 +982,7 @@ class AcquisitionData(DataContainer):
         """
         if self.handle is None:
             raise AssertionError()
-        dt = 'int%s' % cpp_int_bytes()
+        dt = 'int%s' % cpp_int_bits()
         dim = numpy.ndarray((MAX_ACQ_DIMS,), dtype=numpy.dtype(dt))
 #        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
         try_calling(pystir.cSTIR_getAcquisitionDataDimensions(

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -33,7 +33,8 @@ from numbers import Integral, Number
 from deprecation import deprecated
 
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
-     try_calling, assert_validity, cpp_int_bits, cpp_int_array, \
+     try_calling, assert_validity, \
+     cpp_int_bits, cpp_int_dtype, cpp_int_array, \
      examples_data_path, existing_filepath, pTest
 from sirf import SIRF
 from sirf.SIRF import DataContainer
@@ -430,9 +431,7 @@ class ImageData(SIRF.ImageData):
         """Returns image dimensions as a tuple (nz, ny, nx)."""
         if self.handle is None:
             raise AssertionError()
-        dt = 'int%s' % cpp_int_bits()
-        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.dtype(dt))
-#        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
+        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=cpp_int_dtype())
         try_calling(
             pystir.cSTIR_getImageDimensions(self.handle, dim.ctypes.data))
         return tuple(dim[:3])  # [::-1])
@@ -982,9 +981,7 @@ class AcquisitionData(DataContainer):
         """
         if self.handle is None:
             raise AssertionError()
-        dt = 'int%s' % cpp_int_bits()
-        dim = numpy.ndarray((MAX_ACQ_DIMS,), dtype=numpy.dtype(dt))
-#        dim = numpy.ndarray((MAX_IMG_DIMS,), dtype=numpy.int32)
+        dim = numpy.ndarray((MAX_ACQ_DIMS,), dtype=cpp_int_dtype())
         try_calling(pystir.cSTIR_getAcquisitionDataDimensions(
             self.handle, dim.ctypes.data))
         dim = dim[:4]

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -33,7 +33,7 @@ from numbers import Integral, Number
 from deprecation import deprecated
 
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
-     try_calling, assert_validity, \
+     try_calling, assert_validity, cpp_int_bytes, cpp_int_array, \
      examples_data_path, existing_filepath, pTest
 from sirf import SIRF
 from sirf.SIRF import DataContainer


### PR DESCRIPTION
At least on one occasion (see #1028), a Python `int` array passed to C++ turned out to contain 64-bit integers, whereas C++ expected 32-bit integers. This PR introduces checking the size of C++ `int` and creating/converting Python `int` arrays to be passed to C++ accordingly.