### PR TITLE
Trying to fix matplotlib backend issue

### DIFF
--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -107,6 +107,8 @@ def show_2D_array(title, array, scale = None, colorbar = True):
     colorbar: flag specifying whether the colorbar is to be displayed
     '''
     try:
+        import matplotlib
+        matplotlib.use('TkAgg')
         import matplotlib.pyplot as plt
     except:
         print('matplotlib not found, cannot plot the array')
@@ -162,6 +164,7 @@ def show_3D_array\
     import math
     try:
         import matplotlib as mpl
+        mpl.use('TkAgg')
         import matplotlib.pyplot as plt
     except:
         print('matplotlib not found, cannot plot the array')


### PR DESCRIPTION
## Changes in this pull request

Running SIRF scripts on VM 3.3.0-pre2 produced warnings
```
Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.
```
Fixed by installing `tkinter`:
```
sudo apt-get install python3-tk
```
and adding
```
matplotlib.use('TkAgg')
```
in `show_2D_array` and `show_3D_array`.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
