### PR TITLE
Quick fix for dicom output failure #1128

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,11 @@
 # ChangeLog
 ## v3.4.0
 * MR:
-  - added support for spiral trajectories that are pre-computed by the user by exposing a setter.
-  - writing MR images and their attributes to `.dcm` and `.xml` files fixed.
-  - use C++ 17 if Gadgetron-support is enabled
+  - Added support for spiral trajectories that are pre-computed by the user by exposing a setter.
+  - Writing MR images to `.dcm` files quick-fixed. For proper fix, help from Gadgetron team will be sought after moving to using Gadgetron 4.
+  - Use C++ 17 if Gadgetron-support is enabled
 
-* documentation
+* Documentation
   - revision of READMEs for the examples
 
 * Require STIR 5.0

--- a/examples/Python/MR/Gadgetron/fully_sampled_recon_single_chain.py
+++ b/examples/Python/MR/Gadgetron/fully_sampled_recon_single_chain.py
@@ -53,7 +53,13 @@ data_file = args['--file']
 data_path = args['--path']
 if data_path is None:
     data_path = examples_data_path('MR')
+
 output_file = args['--output']
+if output_file[-4:] == '.dcm':
+    dcm_prefix = output_file[: -4]
+else:
+    dcm_prefix = ''
+dcm_output = len(dcm_prefix)
 
 type_to_save = args['--type-to-save']
 show_plot = not args['--non-interactive']
@@ -102,6 +108,8 @@ def main():
 
     # provide raw k-space data as input
     recon.set_input(acq_data)
+    if dcm_output:
+        recon.set_dcm_prefix(dcm_prefix)
 
     # optionally set Gadgetron server host and port
     recon.set_host('localhost')
@@ -121,6 +129,11 @@ def main():
 
     # perform reconstruction
     recon.process()
+
+    if dcm_output:
+        print('== Gadgetron cannot output to both memory and DICOM files, quitting')
+        print('== Set output file extension to .h5 to run the rest of this demo')
+        return
     
     # retrieve reconstructed image data
     image_data = recon.get_output()

--- a/examples/Python/MR/fully_sampled_recon.py
+++ b/examples/Python/MR/fully_sampled_recon.py
@@ -78,7 +78,7 @@ def main():
     # perform reconstruction
     print('---\n reconstructing...')
     recon.process()
-    
+
     # retrieve reconstruced image data
     image_data = recon.get_output().real()
     image_data.write(args['--output'])

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -1050,9 +1050,8 @@ cGT_reconstructImages(void* ptr_recon, void* ptr_input, const char* dcm_prefix)
 		CAST_PTR(DataHandle, h_input, ptr_input);
 		ImagesReconstructor& recon = objectFromHandle<ImagesReconstructor>(h_recon);
 		MRAcquisitionData& input = objectFromHandle<MRAcquisitionData>(h_input);
-		if (strlen(dcm_prefix) < 1)
-			dcm_prefix = 0;
-		recon.process(input, dcm_prefix);
+		recon.set_dcm_prefix(dcm_prefix);
+		recon.process(input);
 		return new DataHandle;
 	}
 	CATCH;

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -154,6 +154,8 @@ void* cGT_newObject(const char* name)
 		NEW_GADGET(PhysioInterpolationGadget);
 		NEW_GADGET(GPURadialSensePrepGadget);
 		NEW_GADGET(GPUCGSenseGadget);
+		NEW_GADGET(FFTGadget);
+		NEW_GADGET(CombineGadget);
 		NEW_GADGET(ExtractGadget);
 		NEW_GADGET(AutoScaleGadget);
 		NEW_GADGET(ComplexToFloatGadget);
@@ -1041,14 +1043,16 @@ cGT_imageParameter(void* ptr_im, const char* name)
 
 extern "C"
 void*
-cGT_reconstructImages(void* ptr_recon, void* ptr_input)
+cGT_reconstructImages(void* ptr_recon, void* ptr_input, const char* dcm_prefix)
 {
 	try {
 		CAST_PTR(DataHandle, h_recon, ptr_recon);
 		CAST_PTR(DataHandle, h_input, ptr_input);
 		ImagesReconstructor& recon = objectFromHandle<ImagesReconstructor>(h_recon);
 		MRAcquisitionData& input = objectFromHandle<MRAcquisitionData>(h_input);
-		recon.process(input);
+		if (strlen(dcm_prefix) < 1)
+			dcm_prefix = 0;
+		recon.process(input, dcm_prefix);
 		return new DataHandle;
 	}
 	CATCH;

--- a/src/xGadgetron/cGadgetron/gadgetron_x.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_x.cpp
@@ -236,7 +236,7 @@ AcquisitionsProcessor::process(MRAcquisitionData& acquisitions)
 }
 
 void 
-ImagesReconstructor::process(MRAcquisitionData& acquisitions, const char* dcm_prefix)
+ImagesReconstructor::process(MRAcquisitionData& acquisitions)
 {
 	uint32_t nacquisitions = 0;
 	nacquisitions = acquisitions.number();
@@ -249,7 +249,7 @@ ImagesReconstructor::process(MRAcquisitionData& acquisitions, const char* dcm_pr
 	conn().register_reader(GADGET_MESSAGE_ISMRMRD_IMAGE,
 		shared_ptr<GadgetronClientMessageReader>
 		(new GadgetronClientImageMessageCollector(sptr_images_)));
-	if (dcm_prefix) {
+	if (dcm_prefix_.size() > 0) {
 		add_gadget("extract", gadgetron::shared_ptr<aGadget>(new ExtractGadget));
 		add_gadget("autoscale", gadgetron::shared_ptr<aGadget>(new AutoScaleGadget));
 		add_writer("writer_dcm", writer_dcm_);
@@ -257,7 +257,7 @@ ImagesReconstructor::process(MRAcquisitionData& acquisitions, const char* dcm_pr
 		set_endgadget(endgadget);
 		conn().register_reader(GADGET_MESSAGE_DICOM_WITHNAME,
 			shared_ptr<GadgetronClientMessageReader>
-			(new GadgetronClientBlobMessageReader(std::string(dcm_prefix), std::string("dcm"))));
+			(new GadgetronClientBlobMessageReader(dcm_prefix_, std::string("dcm"))));
 	}
 	std::string config = xml();
 	//std::cout << "config:\n" << config << std::endl;
@@ -296,7 +296,7 @@ ImagesProcessor::process(const GadgetronImageData& images)
 		THROW("DICOM writer does not support complex images");
 
 	std::string config = xml();
-	std::cout << xml() << '\n';
+	//std::cout << xml() << '\n';
 	GTConnector conn;
 	sptr_images_ = images.new_images_container();
 	if (dicom_)

--- a/src/xGadgetron/cGadgetron/gadgetron_x.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_x.cpp
@@ -236,13 +236,8 @@ AcquisitionsProcessor::process(MRAcquisitionData& acquisitions)
 }
 
 void 
-ImagesReconstructor::process(MRAcquisitionData& acquisitions)
+ImagesReconstructor::process(MRAcquisitionData& acquisitions, const char* dcm_prefix)
 {
-	//check_gadgetron_connection(host_, port_);
-
-	std::string config = xml();
-	//std::cout << "config:\n" << config << std::endl;
-
 	uint32_t nacquisitions = 0;
 	nacquisitions = acquisitions.number();
 	//std::cout << nacquisitions << " acquisitions" << std::endl;
@@ -254,6 +249,19 @@ ImagesReconstructor::process(MRAcquisitionData& acquisitions)
 	conn().register_reader(GADGET_MESSAGE_ISMRMRD_IMAGE,
 		shared_ptr<GadgetronClientMessageReader>
 		(new GadgetronClientImageMessageCollector(sptr_images_)));
+	if (dcm_prefix) {
+		add_gadget("extract", gadgetron::shared_ptr<aGadget>(new ExtractGadget));
+		add_gadget("autoscale", gadgetron::shared_ptr<aGadget>(new AutoScaleGadget));
+		add_writer("writer_dcm", writer_dcm_);
+		gadgetron::shared_ptr<DicomFinishGadget> endgadget(new DicomFinishGadget);
+		set_endgadget(endgadget);
+		conn().register_reader(GADGET_MESSAGE_DICOM_WITHNAME,
+			shared_ptr<GadgetronClientMessageReader>
+			(new GadgetronClientBlobMessageReader(std::string(dcm_prefix), std::string("dcm"))));
+	}
+	std::string config = xml();
+	//std::cout << "config:\n" << config << std::endl;
+
 	for (int nt = 0; nt < N_TRIALS; nt++) {
 		try {
 			conn().connect(host_, port_);
@@ -288,6 +296,7 @@ ImagesProcessor::process(const GadgetronImageData& images)
 		THROW("DICOM writer does not support complex images");
 
 	std::string config = xml();
+	std::cout << xml() << '\n';
 	GTConnector conn;
 	sptr_images_ = images.new_images_container();
 	if (dicom_)

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
@@ -97,7 +97,7 @@ extern "C" {
 		int from, int till, int n, PTR_FLOAT values);
 
 	// image methods
-	void* cGT_reconstructImages(void* ptr_recon, void* ptr_input);
+	void* cGT_reconstructImages(void* ptr_recon, void* ptr_input, const char* dcm_prefix);
 	void* cGT_reconstructedImages(void* ptr_recon);
     void* cGT_readImages(const char* file);
 	void* cGT_ImageFromAcquisitiondata(void* ptr_acqs);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadget_lib.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadget_lib.h
@@ -183,13 +183,15 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Base class for generators of xml-definitions of image writer gadgets.
+	*/
 	class ImageMessageWriter : public aGadget {
-
 	};
+
 	/**
 	\brief Class for MRIImageWriter gadget xml-definition generator.
 	*/
-	//class IsmrmrdImgMsgWriter : public aGadget {
 	class IsmrmrdImgMsgWriter : public ImageMessageWriter {
 	public:
 		static const char* class_name()
@@ -235,6 +237,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of NoiseAdjustGadget.
+	*/
 	class NoiseAdjustGadget : public Gadget {
 	public:
 		NoiseAdjustGadget() :
@@ -246,6 +251,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of PCACoilGadget.
+	*/
 	class PCACoilGadget : public Gadget {
 	public:
 		PCACoilGadget() :
@@ -257,6 +265,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of CoilReductionGadget.
+	*/
 	class CoilReductionGadget : public Gadget {
 	public:
 		CoilReductionGadget() :
@@ -271,6 +282,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of AsymmetricEchoAdjustROGadget.
+	*/
 	class AsymmetricEchoAdjustROGadget : public Gadget {
 	public:
 		AsymmetricEchoAdjustROGadget() :
@@ -283,6 +297,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of RemoveROOversamplingGadget.
+	*/
 	class RemoveROOversamplingGadget : public Gadget {
 	public:
 		RemoveROOversamplingGadget() :
@@ -295,6 +312,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of AcquisitionAccumulateTriggerGadget.
+	*/
 	class AcquisitionAccumulateTriggerGadget : public Gadget {
 	public:
 		AcquisitionAccumulateTriggerGadget() :
@@ -309,6 +329,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of BucketToBufferGadget.
+	*/
 	class BucketToBufferGadget : public Gadget {
 	public:
 		BucketToBufferGadget() :
@@ -326,6 +349,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GenericReconCartesianReferencePrepGadget.
+	*/
 	class GenericReconCartesianReferencePrepGadget : public Gadget {
 	public:
 		GenericReconCartesianReferencePrepGadget() :
@@ -345,6 +371,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of SimpleReconGadget.
+	*/
 	class SimpleReconGadget : public Gadget {
 	public:
 		SimpleReconGadget() :
@@ -356,6 +385,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of FFTGadget.
+	*/
 	class FFTGadget : public Gadget {
 	public:
 		FFTGadget() :
@@ -367,6 +399,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of CombineGadget.
+	*/
 	class CombineGadget : public Gadget {
 	public:
 		CombineGadget() :
@@ -378,6 +413,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GenericReconCartesianFFTGadget.
+	*/
 	class GenericReconCartesianFFTGadget : public Gadget {
 	public:
 		GenericReconCartesianFFTGadget() :
@@ -395,6 +433,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GenericReconCartesianGrappaGadget.
+	*/
 	class GenericReconCartesianGrappaGadget : public Gadget {
 	public:
 		GenericReconCartesianGrappaGadget() :
@@ -417,6 +458,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GenericReconFieldOfViewAdjustmentGadget.
+	*/
 	class GenericReconFieldOfViewAdjustmentGadget : public Gadget {
 	public:
 		GenericReconFieldOfViewAdjustmentGadget() :
@@ -433,6 +477,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GenericReconImageArrayScalingGadget.
+	*/
 	class GenericReconImageArrayScalingGadget : public Gadget {
 	public:
 		GenericReconImageArrayScalingGadget() :
@@ -454,6 +501,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of FatWaterGadget.
+	*/
 	class FatWaterGadget : public Gadget {
 	public:
 		FatWaterGadget() :
@@ -465,6 +515,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of ImageArraySplitGadget.
+	*/
 	class ImageArraySplitGadget : public Gadget {
 	public:
 		ImageArraySplitGadget() :
@@ -476,6 +529,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of PhysioInterpolationGadget.
+	*/
 	class PhysioInterpolationGadget : public Gadget {
 	public:
 		PhysioInterpolationGadget() :
@@ -492,6 +548,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GPURadialPrepGadget.
+	*/
 	class GPURadialPrepGadget : public Gadget {
 	public:
 		GPURadialPrepGadget(std::string name, std::string dll, std::string cl) :
@@ -519,6 +578,9 @@ namespace sirf {
 */
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GPURadialSensePrepGadget.
+	*/
 	class GPURadialSensePrepGadget : public GPURadialPrepGadget {
 	public:
 		GPURadialSensePrepGadget() :
@@ -530,6 +592,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GPUSenseGadget.
+	*/
 	class GPUSenseGadget : public Gadget {
 	public:
 		GPUSenseGadget(std::string name, std::string dll, std::string cl) :
@@ -553,6 +618,9 @@ namespace sirf {
 */
 	};
 
+	/**
+	\brief Class for the generator of xml definition of GPUCGSenseGadget.
+	*/
 	class GPUCGSenseGadget : public GPUSenseGadget {
 	public:
 		GPUCGSenseGadget() : 
@@ -568,6 +636,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of ExtractGadget.
+	*/
 	class ExtractGadget : public Gadget {
 	public:
 		ExtractGadget() :
@@ -585,6 +656,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of AutoScaleGadget.
+	*/
 	class AutoScaleGadget : public Gadget {
 	public:
 		AutoScaleGadget() :
@@ -596,6 +670,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of ComplexToFloatGadget.
+	*/
 	class ComplexToFloatGadget : public Gadget {
 	public:
 		ComplexToFloatGadget() :
@@ -607,6 +684,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of FloatToFixPointGadget.
+	*/
 	class FloatToFixPointGadget : public Gadget {
 	public:
 		FloatToFixPointGadget(std::string name, // = "FloatToFixPoint", 
@@ -627,6 +707,9 @@ namespace sirf {
 */
 	};
 
+	/**
+	\brief Class for the generator of xml definition of FloatToUShortGadget.
+	*/
 	class FloatToUShortGadget : public FloatToFixPointGadget {
 	public:
 		FloatToUShortGadget() :
@@ -638,6 +721,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of FloatToShortGadget.
+	*/
 	class FloatToShortGadget : public FloatToFixPointGadget {
 	public:
 		FloatToShortGadget() :
@@ -666,6 +752,9 @@ namespace sirf {
 		}
 	};
 */
+	/**
+	\brief Class for the generator of xml definition of ImageFinishGadget.
+	*/
 	class ImageFinishGadget : public Gadget {
 	public:
 		ImageFinishGadget() :
@@ -677,6 +766,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of DicomFinishGadget.
+	*/
 	class DicomFinishGadget : public Gadget {
 	public:
 		DicomFinishGadget() :
@@ -688,6 +780,9 @@ namespace sirf {
 		}
 	};
 
+	/**
+	\brief Class for the generator of xml definition of AcquisitionFinishGadget.
+	*/
 	class AcquisitionFinishGadget : public Gadget {
 	public:
 		AcquisitionFinishGadget() :

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadget_lib.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadget_lib.h
@@ -356,7 +356,29 @@ namespace sirf {
 		}
 	};
 
-    class GenericReconCartesianFFTGadget : public Gadget {
+	class FFTGadget : public Gadget {
+	public:
+		FFTGadget() :
+			Gadget("FFT", "gadgetron_mricore", "FFTGadget")
+		{}
+		static const char* class_name()
+		{
+			return "FFTGadget";
+		}
+	};
+
+	class CombineGadget : public Gadget {
+	public:
+		CombineGadget() :
+			Gadget("Combine", "gadgetron_mricore", "CombineGadget")
+		{}
+		static const char* class_name()
+		{
+			return "CombineGadget";
+		}
+	};
+
+	class GenericReconCartesianFFTGadget : public Gadget {
 	public:
 		GenericReconCartesianFFTGadget() :
 			Gadget("Recon", "gadgetron_mricore", "GenericReconCartesianFFTGadget")

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_client.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_client.h
@@ -213,12 +213,14 @@ namespace sirf {
 			, file_prefix(fileprefix)
 			, file_suffix(filesuffix)
 		{
+			//std::cout << fileprefix << '.' << filesuffix << '\n';
 		}
 
 		virtual ~GadgetronClientBlobMessageReader() {}
 
 		virtual void read(boost::asio::ip::tcp::socket* socket)
 		{
+			//std::cout << "in GadgetronClientBlobMessageReader::read...\n";
 			// MUST READ 32-bits
 			uint32_t nbytes;
 			boost::asio::read(*socket, boost::asio::buffer(&nbytes, sizeof(uint32_t)));
@@ -255,7 +257,7 @@ namespace sirf {
 			filename << "." << file_suffix;
 			filename_attrib.append("_attrib.xml");
 
-			std::cout << "Writing image " << filename.str() << std::endl;
+			//std::cout << "Writing image " << filename.str() << std::endl;
 
 			std::ofstream outfile;
 			outfile.open(filename.str().c_str(), std::ios::out | std::ios::binary);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -257,9 +257,19 @@ namespace sirf {
 		{
 			dcm_prefix_ = dcm_prefix;
 		}
+		std::string dcm_prefix() const
+		{
+			return dcm_prefix_;
+		}
+		bool dcm_output() const
+		{
+			return dcm_prefix_.size() > 1;
+		}
 		void process(MRAcquisitionData& acquisitions);
 		gadgetron::shared_ptr<GadgetronImageData> get_output()
 		{
+			if (dcm_output())
+				THROW("Output to both memory and DICOM files not implemented.");
 			return sptr_images_;
 		}
 

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -253,13 +253,18 @@ namespace sirf {
 			return "ImagesReconstructor";
 		}
 
-		void process(MRAcquisitionData& acquisitions, const char* dcm_prefix = 0);
+		void set_dcm_prefix(const char* dcm_prefix)
+		{
+			dcm_prefix_ = dcm_prefix;
+		}
+		void process(MRAcquisitionData& acquisitions);
 		gadgetron::shared_ptr<GadgetronImageData> get_output()
 		{
 			return sptr_images_;
 		}
 
 	private:
+		std::string dcm_prefix_;
 		gadgetron::shared_ptr<IsmrmrdAcqMsgReader> reader_;
 		gadgetron::shared_ptr<IsmrmrdImgMsgWriter> writer_;
 		gadgetron::shared_ptr<DicomImageMessageWriter> writer_dcm_;

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -253,7 +253,7 @@ namespace sirf {
 			return "ImagesReconstructor";
 		}
 
-		void process(MRAcquisitionData& acquisitions, const char* dcm_prefix = "image");
+		void process(MRAcquisitionData& acquisitions, const char* dcm_prefix = 0);
 		gadgetron::shared_ptr<GadgetronImageData> get_output()
 		{
 			return sptr_images_;

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -239,9 +239,9 @@ namespace sirf {
 
 		ImagesReconstructor() :
 			reader_(new IsmrmrdAcqMsgReader),
-			writer_(new IsmrmrdImgMsgWriter)
+			writer_(new IsmrmrdImgMsgWriter),
+			writer_dcm_(new DicomImageMessageWriter)
 		{
-			//class_ = "ImagesReconstructor";
 			sptr_images_.reset();
 			add_reader("reader", reader_);
 			add_writer("writer", writer_);
@@ -253,7 +253,7 @@ namespace sirf {
 			return "ImagesReconstructor";
 		}
 
-		void process(MRAcquisitionData& acquisitions);
+		void process(MRAcquisitionData& acquisitions, const char* dcm_prefix = "image");
 		gadgetron::shared_ptr<GadgetronImageData> get_output()
 		{
 			return sptr_images_;
@@ -262,6 +262,7 @@ namespace sirf {
 	private:
 		gadgetron::shared_ptr<IsmrmrdAcqMsgReader> reader_;
 		gadgetron::shared_ptr<IsmrmrdImgMsgWriter> writer_;
+		gadgetron::shared_ptr<DicomImageMessageWriter> writer_dcm_;
 		gadgetron::shared_ptr<GadgetronImageData> sptr_images_;
 	};
 

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -253,7 +253,11 @@ namespace sirf {
 			return "ImagesReconstructor";
 		}
 
-		void set_dcm_prefix(const char* dcm_prefix)
+		/**
+		\brief Setting dcm prefix to a non-empty string redirects the output
+		       images to DICOM files (cf. get_output() below).
+		*/
+		void set_dcm_prefix(const std::string& dcm_prefix)
 		{
 			dcm_prefix_ = dcm_prefix;
 		}
@@ -263,7 +267,7 @@ namespace sirf {
 		}
 		bool dcm_output() const
 		{
-			return dcm_prefix_.size() > 1;
+			return !dcm_prefix_.empty();
 		}
 		void process(MRAcquisitionData& acquisitions);
 		gadgetron::shared_ptr<GadgetronImageData> get_output()

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1420,6 +1420,7 @@ class Reconstructor(GadgetChain):
         self.handle = pygadgetron.cGT_newObject('ImagesReconstructor')
         check_status(self.handle)
         self.input_data = None
+        self.dcm_prefix = ""
         if list is None:
             return
         for i in range(len(list)):
@@ -1435,7 +1436,9 @@ class Reconstructor(GadgetChain):
         '''
         assert isinstance(input_data, AcquisitionData)
         self.input_data = input_data
-    def process(self, dcm_prefix=None):
+    def set_dcm_prefix(self, dcm_prefix):
+        self.dcm_prefix = dcm_prefix
+    def process(self):
         '''
         Processes the input with the gadget chain.
         dcm_prefix: Python text string.
@@ -1446,10 +1449,8 @@ class Reconstructor(GadgetChain):
         '''
         if self.input_data is None:
             raise error('no input data')
-        if dcm_prefix is None:
-            dcm_prefix = ""
         try_calling(pygadgetron.cGT_reconstructImages\
-             (self.handle, self.input_data.handle, dcm_prefix))
+             (self.handle, self.input_data.handle, self.dcm_prefix))
     def get_output(self, subset = None):
         '''
         Returns specified subset of the output ImageData. If no subset is 
@@ -1463,16 +1464,14 @@ class Reconstructor(GadgetChain):
             return output
         else:
             return output.select('GADGETRON_DataRole', subset)
-    def reconstruct(self, input_data, dcm_prefix=None):
+    def reconstruct(self, input_data):
         '''
         Returns the output from the chain for specified input.
         input_data: AcquisitionData
         '''
         assert_validity(input_data, AcquisitionData)
-        if dcm_prefix is None:
-            dcm_prefix = ""
         handle = pygadgetron.cGT_reconstructImages\
-             (self.handle, input_data.handle, dcm_prefix)
+             (self.handle, input_data.handle, self.dcm_prefix)
         check_status(handle)
         pyiutil.deleteDataHandle(handle)
         images = ImageData()
@@ -1599,6 +1598,7 @@ class FullySampledReconstructor(Reconstructor):
         self.handle = pygadgetron.cGT_newObject('SimpleReconstructionprocessor')
         check_status(self.handle)
         self.input_data = None
+        self.dcm_prefix = ""
     def __del__(self):
         if self.handle is not None:
             pyiutil.deleteDataHandle(self.handle)
@@ -1613,6 +1613,7 @@ class CartesianGRAPPAReconstructor(Reconstructor):
             ('SimpleGRAPPAReconstructionprocessor')
         check_status(self.handle)
         self.input_data = None
+        self.dcm_prefix = ""
     def __del__(self):
         if self.handle is not None:
             pyiutil.deleteDataHandle(self.handle)

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1415,7 +1415,7 @@ class Reconstructor(GadgetChain):
     Class for a chain of gadgets that has AcquisitionData on input and 
     ImageData on output.
     '''
-    def __init__(self, list = None):
+    def __init__(self, list=None):
         self.handle = None
         self.handle = pygadgetron.cGT_newObject('ImagesReconstructor')
         check_status(self.handle)
@@ -1435,14 +1435,21 @@ class Reconstructor(GadgetChain):
         '''
         assert isinstance(input_data, AcquisitionData)
         self.input_data = input_data
-    def process(self):
+    def process(self, dcm_prefix=None):
         '''
         Processes the input with the gadget chain.
+        dcm_prefix: Python text string.
+        If dcm_prefix is not None, the reconstructed images are written to
+        files <dcm_prefix>_<image number>.dcm.
+        Otherwise, they are stored in memory and can be retrieved by
+        get_output().
         '''
         if self.input_data is None:
             raise error('no input data')
+        if dcm_prefix is None:
+            dcm_prefix = ""
         try_calling(pygadgetron.cGT_reconstructImages\
-             (self.handle, self.input_data.handle))
+             (self.handle, self.input_data.handle, dcm_prefix))
     def get_output(self, subset = None):
         '''
         Returns specified subset of the output ImageData. If no subset is 

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1463,14 +1463,16 @@ class Reconstructor(GadgetChain):
             return output
         else:
             return output.select('GADGETRON_DataRole', subset)
-    def reconstruct(self, input_data):
+    def reconstruct(self, input_data, dcm_prefix=None):
         '''
         Returns the output from the chain for specified input.
         input_data: AcquisitionData
         '''
         assert_validity(input_data, AcquisitionData)
+        if dcm_prefix is None:
+            dcm_prefix = ""
         handle = pygadgetron.cGT_reconstructImages\
-             (self.handle, input_data.handle)
+             (self.handle, input_data.handle, dcm_prefix)
         check_status(handle)
         pyiutil.deleteDataHandle(handle)
         images = ImageData()

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1442,7 +1442,7 @@ class Reconstructor(GadgetChain):
         '''
         Processes the input with the gadget chain.
         dcm_prefix: Python text string.
-        If dcm_prefix is not None, the reconstructed images are written to
+        If dcm_prefix is not "", the reconstructed images are written to
         files <dcm_prefix>_<image number>.dcm.
         Otherwise, they are stored in memory and can be retrieved by
         get_output().


### PR DESCRIPTION
## Changes in this pull request
Enabled dicom output for MR reconstruction with Gadgetron.

## Testing performed
Tested on examples.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Quick fixes #1128.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
