### PR TITLE
[GHA] test with gcc 8 and 9

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,11 +20,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # the agent machine operating systems
-        os: [ubuntu-latest]
-        DEVEL_BUILD: ["OFF", "ON"]
-        EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
-        CMAKE_BUILD_TYPE: ["Release"]
+        include:
+        - os: [ubuntu-latest]
+          compiler: gcc
+          compiler_version: 8
+          DEVEL_BUILD: "OFF"
+          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
+          CMAKE_BUILD_TYPE: ["Release"]
+        - os: [ubuntu-latest]
+          compiler: gcc
+          compiler_version: 9
+          DEVEL_BUILD: "OFF"
+          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
+          CMAKE_BUILD_TYPE: ["Release"]
+        - os: [ubuntu-latest]
+          compiler: gcc
+          compiler_version: 9
+          DEVEL_BUILD: "ON"
+          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
+          CMAKE_BUILD_TYPE: ["Release"]
+        - os: [ubuntu-latest]
+          compiler: gcc
+          compiler_version: 10
+          DEVEL_BUILD: "ON"
+          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
+          CMAKE_BUILD_TYPE: ["Release"]
         # let's run all of them, as opposed to aborting when one fails
       fail-fast: false
 
@@ -47,6 +67,27 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1
       with:
         key: ${{ matrix.os }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ matrix.DEVEL_BUILD }}
+    - name: set_compiler_variables
+      shell: bash
+      run: |
+          set -ex
+          if test 'XX${{ matrix.compiler }}' = 'XXclang'; then
+            CC="clang"
+            CXX="clang++"
+          elif test 'XX${{ matrix.compiler }}' = 'XXgcc'; then
+            CC="gcc"
+            CXX="g++"
+          fi
+          if test 'XX${{ matrix.compiler_version }}' != 'XX'; then
+            CC=${CC}-${{ matrix.compiler_version }}
+            CXX=${CXX}-${{ matrix.compiler_version }}
+            sudo apt install -yq ${CXX} ${CC}
+          fi
+
+          export CC CXX
+          # make available to jobs below
+          echo CC="$CC" >> $GITHUB_ENV
+          echo CXX="$CXX" >> $GITHUB_ENV
     - name: configure
       shell: bash
       env:
@@ -64,8 +105,6 @@ jobs:
           BUILD_FLAGS="$BUILD_FLAGS -DBUILD_TESTING_GADGETRON=OFF -DBUILD_TESTING_ISMRMRD=OFF"
           mkdir -p build/;
           cd build;
-          export CC="gcc-8";
-          export CXX="g++-8";
           source ~/virtualenv/bin/activate;
           cmake -S ../SIRF-SuperBuild ${BUILD_FLAGS} ${EXTRA_BUILD_FLAGS} ${DEVEL_BUILD};
     - name: build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,13 +39,14 @@ jobs:
           DEVEL_BUILD: "ON"
           EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
           CMAKE_BUILD_TYPE: "Release"
-        - os: ubuntu-latest
-          compiler: gcc
-          compiler_version: 10
-          DEVEL_BUILD: "ON"
-          EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
-          CMAKE_BUILD_TYPE: "Release"
-        # let's run all of them, as opposed to aborting when one fails
+        # need to upgrade Gadgetron before we can enable gcc 10
+        #- os: ubuntu-latest
+        #  compiler: gcc
+        #  compiler_version: 10
+        #  DEVEL_BUILD: "ON"
+        #  EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
+        #  CMAKE_BUILD_TYPE: "Release"
+      # let's run all of them, as opposed to aborting when one fails
       fail-fast: false
 
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,30 +21,30 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: [ubuntu-latest]
+        - os: ubuntu-latest
           compiler: gcc
           compiler_version: 8
           DEVEL_BUILD: "OFF"
-          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
-          CMAKE_BUILD_TYPE: ["Release"]
-        - os: [ubuntu-latest]
+          EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
+          CMAKE_BUILD_TYPE: "Release"
+        - os: ubuntu-latest
           compiler: gcc
           compiler_version: 9
           DEVEL_BUILD: "OFF"
-          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
-          CMAKE_BUILD_TYPE: ["Release"]
-        - os: [ubuntu-latest]
+          EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
+          CMAKE_BUILD_TYPE: "Release"
+        - os: ubuntu-latest
           compiler: gcc
           compiler_version: 9
           DEVEL_BUILD: "ON"
-          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
-          CMAKE_BUILD_TYPE: ["Release"]
-        - os: [ubuntu-latest]
+          EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
+          CMAKE_BUILD_TYPE: "Release"
+        - os: ubuntu-latest
           compiler: gcc
           compiler_version: 10
           DEVEL_BUILD: "ON"
-          EXTRA_BUILD_FLAGS: ["-DUSE_ITK=ON"]
-          CMAKE_BUILD_TYPE: ["Release"]
+          EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
+          CMAKE_BUILD_TYPE: "Release"
         # let's run all of them, as opposed to aborting when one fails
       fail-fast: false
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,25 +88,23 @@ jobs:
           # make available to jobs below
           echo CC="$CC" >> $GITHUB_ENV
           echo CXX="$CXX" >> $GITHUB_ENV
+
     - name: configure
       shell: bash
-      env:
-          EXTRA_BUILD_FLAGS: ${{ matrix.EXTRA_BUILD_FLAGS }}
-          CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE }}
-          DEVEL_BUILD: "-DDEVEL_BUILD=${{ matrix.DEVEL_BUILD }}"
       run: |
           set -ex;
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           cmake --version
-          #echo "cmake flags $BUILD_FLAGS $EXTRA_BUILD_FLAGS"          
-          BUILD_FLAGS="-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_Armadillo=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DCMAKE_INSTALL_PREFIX=~/install -DPYVER=3";
+          #echo "cmake flags ${{ matrix.CMAKE_BUILD_TYPE }} ${{ matrix.EXTRA_BUILD_FLAGS }}"
+          BUILD_FLAGS="-DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_Armadillo=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DCMAKE_INSTALL_PREFIX=~/install -DPYVER=3";
           BUILD_FLAGS="$BUILD_FLAGS -DSIRF_SOURCE_DIR:PATH=${GITHUB_WORKSPACE} -DDISABLE_GIT_CHECKOUT_SIRF=ON"
           # only test SIRF (others are tested in the SIRF-SuperBuild action)
           BUILD_FLAGS="$BUILD_FLAGS -DBUILD_TESTING_GADGETRON=OFF -DBUILD_TESTING_ISMRMRD=OFF"
+          DEVEL_BUILD="-DDEVEL_BUILD=${{ matrix.DEVEL_BUILD }}"
           mkdir -p build/;
           cd build;
           source ~/virtualenv/bin/activate;
-          cmake -S ../SIRF-SuperBuild ${BUILD_FLAGS} ${EXTRA_BUILD_FLAGS} ${DEVEL_BUILD};
+          cmake -S ../SIRF-SuperBuild ${BUILD_FLAGS} ${{ matrix.EXTRA_BUILD_FLAGS }} ${DEVEL_BUILD};
     - name: build
       shell: bash
       run: 


### PR DESCRIPTION
port some changes from the SIRF-SuperBuild.

Fixes #1140, as we no longer assume gcc-8 is installed.