### PR TITLE
Change prefix from PETAcquisitionData to STIRAcquisitionData.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   - Added support for spiral trajectories that are pre-computed by the user by exposing a setter.
   - Writing MR images to `.dcm` files quick-fixed. For proper fix, help from Gadgetron team will be sought after moving to using Gadgetron 4.
   - Use C++ 17 if Gadgetron-support is enabled
+  - Renamed PETAcquisitionData and derived classes to STIRAcquisitionData* as STIR now supports SPECT in addition to PET modality. Backward compatibility ensured by defining old nomenclature via typedefs until the release of SIRF 4.
 
 * Documentation
   - revision of READMEs for the examples

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -308,11 +308,11 @@ void* cSTIR_objectFromFile(const char* name, const char* filename)
 		}
 		if (sirf::iequals(name, "AcquisitionData")) {
 
-            std::shared_ptr<PETAcquisitionData> sptr;
-            if (PETAcquisitionData::storage_scheme().compare("file") == 0)
-                sptr.reset(new PETAcquisitionDataInFile(filename));
+            std::shared_ptr<STIRAcquisitionData> sptr;
+            if (STIRAcquisitionData::storage_scheme().compare("file") == 0)
+                sptr.reset(new STIRAcquisitionDataInFile(filename));
             else
-                sptr.reset(new PETAcquisitionDataInMemory(filename));
+                sptr.reset(new STIRAcquisitionDataInMemory(filename));
 			return newObjectHandle(sptr);
 		}
 		if (sirf::iequals(name, "ListmodeToSinograms")) {
@@ -415,7 +415,7 @@ void* cSTIR_scatterSimulatorFwdReplace
 	try {
 		auto& am = objectFromHandle<PETSingleScatterSimulator>(ptr_am);
 		auto& id = objectFromHandle<STIRImageData>(ptr_im);
-		auto& ad = objectFromHandle<PETAcquisitionData>(ptr_ad);
+		auto& ad = objectFromHandle<STIRAcquisitionData>(ptr_ad);
                 am.forward(ad, id);
 		return new DataHandle;
 	}
@@ -429,7 +429,7 @@ void* cSTIR_setupScatterSimulator
 	try {
 		auto& am = objectFromHandle<PETSingleScatterSimulator>(ptr_am);
 		SPTR_FROM_HANDLE(STIRImageData, id, ptr_im);
-		SPTR_FROM_HANDLE(PETAcquisitionData, ad, ptr_ad);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, ad, ptr_ad);
                 am.set_up(ad, id);
 		return new DataHandle;
 	}
@@ -521,7 +521,7 @@ void* cSTIR_createPETAcquisitionSensitivityModel
 	try {
 		shared_ptr<PETAcquisitionSensitivityModel> sptr;
 		if (sirf::iequals(src, "s")) {
-			PETAcquisitionData& ad = objectFromHandle<PETAcquisitionData>(ptr_src);
+			STIRAcquisitionData& ad = objectFromHandle<STIRAcquisitionData>(ptr_src);
 			sptr.reset(new PETAcquisitionSensitivityModel(ad));
 		}
 		else if (sirf::iequals(src, "n")) {
@@ -568,7 +568,7 @@ void* cSTIR_setupAcquisitionSensitivityModel(void* ptr_sm, void* ptr_ad)
 	try {
 		PETAcquisitionSensitivityModel& sm = 
 			objectFromHandle<PETAcquisitionSensitivityModel>(ptr_sm);
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_ad);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_ad);
 		sm.set_up(sptr_ad->get_exam_info_sptr(),
 			sptr_ad->get_proj_data_info_sptr()->create_shared_clone());
 		return (void*) new DataHandle;
@@ -583,7 +583,7 @@ void* cSTIR_applyAcquisitionSensitivityModel
 	try {
 		PETAcquisitionSensitivityModel& sm =
 			objectFromHandle<PETAcquisitionSensitivityModel>(ptr_sm);
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_ad);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_ad);
 
 		if (sirf::iequals(job, "fwd"))
 			return newObjectHandle(sm.forward(*sptr_ad));
@@ -606,7 +606,7 @@ void* cSTIR_setupAcquisitionModel(void* ptr_am, void* ptr_dt, void* ptr_im)
 	try {
 		//writeText("setting up acquisition model\n");
 		AcqMod3DF& am = objectFromHandle<AcqMod3DF>(ptr_am);
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_dt, ptr_dt);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_dt, ptr_dt);
 		SPTR_FROM_HANDLE(STIRImageData, sptr_id, ptr_im);
 		am.set_up(sptr_dt, sptr_id);
 		return (void*) new DataHandle;
@@ -653,7 +653,7 @@ void* cSTIR_acquisitionModelFwdReplace
 	try {
 		AcqMod3DF& am = objectFromHandle<AcqMod3DF>(ptr_am);
 		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_im);
-		PETAcquisitionData& ad = objectFromHandle<PETAcquisitionData>(ptr_ad);
+		STIRAcquisitionData& ad = objectFromHandle<STIRAcquisitionData>(ptr_ad);
 		am.forward(ad, id, subset_num, num_subsets, num_subsets > 1);
 		return new DataHandle;
 	}
@@ -666,7 +666,7 @@ void* cSTIR_acquisitionModelBwd(void* ptr_am, void* ptr_ad,
 {
 	try {
 		AcqMod3DF& am = objectFromHandle<AcqMod3DF>(ptr_am);
-		PETAcquisitionData& ad = objectFromHandle<PETAcquisitionData>(ptr_ad);
+		STIRAcquisitionData& ad = objectFromHandle<STIRAcquisitionData>(ptr_ad);
 		return newObjectHandle(am.backward(ad, subset_num, num_subsets));
 	}
 	CATCH;
@@ -691,7 +691,7 @@ void* cSTIR_acquisitionModelBwdReplace(void* ptr_am, void* ptr_ad,
 {
 	try {
 		AcqMod3DF& am = objectFromHandle<AcqMod3DF>(ptr_am);
-		PETAcquisitionData& ad = objectFromHandle<PETAcquisitionData>(ptr_ad);
+		STIRAcquisitionData& ad = objectFromHandle<STIRAcquisitionData>(ptr_ad);
 		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_im);
 		am.backward(id, ad, subset_num, num_subsets);
 		return new DataHandle;
@@ -716,9 +716,9 @@ cSTIR_setAcquisitionDataStorageScheme(const char* scheme)
 { 
 	try {
 		if (scheme[0] == 'f' || strcmp(scheme, "default") == 0)
-			PETAcquisitionDataInFile::set_as_template();
+			STIRAcquisitionDataInFile::set_as_template();
 		else
-			PETAcquisitionDataInMemory::set_as_template();
+			STIRAcquisitionDataInMemory::set_as_template();
 		return (void*)new DataHandle;
 	}
 	CATCH;
@@ -729,15 +729,15 @@ void*
 cSTIR_getAcquisitionDataStorageScheme()
 {
 	return charDataHandleFromCharData
-		(PETAcquisitionData::storage_scheme().c_str());
+		(STIRAcquisitionData::storage_scheme().c_str());
 }
 
 extern "C"
 void* cSTIR_acquisitionDataFromTemplate(void* ptr_t)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_t, ptr_t);
-                std::shared_ptr<PETAcquisitionData> sptr(sptr_t->new_acquisition_data());
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_t, ptr_t);
+                std::shared_ptr<STIRAcquisitionData> sptr(sptr_t->new_acquisition_data());
 		return newObjectHandle(sptr);
 	}
 	CATCH;
@@ -747,8 +747,8 @@ extern "C"
 void* cSTIR_cloneAcquisitionData(void* ptr_ad)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_ad);
-                std::shared_ptr<PETAcquisitionData> sptr(sptr_ad->clone());
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_ad);
+                std::shared_ptr<STIRAcquisitionData> sptr(sptr_ad->clone());
 		return newObjectHandle(sptr);
 	}
 	CATCH;
@@ -765,8 +765,8 @@ const int num_tof_bins_to_combine
 )
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_t, ptr_t);
-                std::shared_ptr<PETAcquisitionData> sptr =
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_t, ptr_t);
+                std::shared_ptr<STIRAcquisitionData> sptr =
 			sptr_t->single_slice_rebinned_data(
 			num_segments_to_combine,
 			num_views_to_combine,
@@ -788,15 +788,15 @@ void* cSTIR_acquisitionDataFromScannerInfo
                 stir::shared_ptr<ExamInfo> sptr_ei(new ExamInfo());
         sptr_ei->imaging_modality = ImagingModality::PT;
 		stir::shared_ptr<stir::ProjDataInfo> sptr_pdi =
-			PETAcquisitionData::proj_data_info_from_scanner
+			STIRAcquisitionData::proj_data_info_from_scanner
 			(scanner, span, max_ring_diff, view_mash_factor);
 #if STIR_VERSION >= 050000
                 sptr_pdi->set_tof_mash_factor(tof_mash_factor);
 #endif
-		PETAcquisitionDataInFile::init();
-		std::shared_ptr<PETAcquisitionData> sptr_t =
-			PETAcquisitionData::storage_template();
-		std::shared_ptr<PETAcquisitionData> sptr(sptr_t->same_acquisition_data
+		STIRAcquisitionDataInFile::init();
+		std::shared_ptr<STIRAcquisitionData> sptr_t =
+			STIRAcquisitionData::storage_template();
+		std::shared_ptr<STIRAcquisitionData> sptr(sptr_t->same_acquisition_data
 			(sptr_ei, sptr_pdi));
 		sptr->fill(0.0f);
 		return newObjectHandle(sptr);
@@ -809,7 +809,7 @@ void* cSTIR_getAcquisitionDataDimensions(const void* ptr_acq, size_t ptr_dim)
 {
 	try {
 		int* dim = (int*)ptr_dim;
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
 		dim[0] = sptr_ad->get_num_tangential_poss();
 		dim[1] = sptr_ad->get_num_views();
 		dim[2] = sptr_ad->get_num_non_TOF_sinograms();
@@ -824,7 +824,7 @@ void* cSTIR_getAcquisitionData(const void* ptr_acq, size_t ptr_data)
 {
 	try {
 		float* data = (float*)ptr_data;
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
 		if (sptr_ad->is_empty())
 			return DataHandle::error_handle(
 				"Failed to get acquisition data: dealing with empty template?",
@@ -839,7 +839,7 @@ extern "C"
 void* cSTIR_fillAcquisitionData(void* ptr_acq, float v)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
 		sptr_ad->fill(v);
 		return (void*)new DataHandle;
 	}
@@ -851,8 +851,8 @@ void* cSTIR_fillAcquisitionDataFromAcquisitionData
 (void* ptr_acq, const void* ptr_from)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_from, ptr_from);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_from, ptr_from);
 		sptr_ad->fill(*sptr_from);
 		return (void*)new DataHandle;
 	}
@@ -863,7 +863,7 @@ extern "C"
 void* cSTIR_setAcquisitionData(void* ptr_acq, size_t ptr_data)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
 		float *data = (float *)ptr_data;
 		sptr_ad->fill_from(data);
 		return (void*)new DataHandle;
@@ -875,7 +875,7 @@ extern "C"
 void* cSTIR_writeAcquisitionData(void* ptr_acq, const char* filename)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
 		sptr_ad->write(filename);
 		return (void*)new DataHandle;
 	}
@@ -886,7 +886,7 @@ extern "C"
 void* cSTIR_get_ProjDataInfo(void* ptr_acq)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
 		return charDataHandleFromCharData(
 			sptr_ad->get_proj_data_info_sptr()->parameter_info().c_str());
 	}
@@ -897,10 +897,10 @@ extern "C"
 void* cSTIR_get_subset(void* ptr_acq, int nv, size_t ptr_views)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_acq);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_acq);
 		int* ptr_v = (int*)ptr_views;
 		std::vector<int> v(ptr_v, ptr_v + nv);
-		std::shared_ptr<PETAcquisitionData> sptr = std::move(sptr_ad->get_subset(v));
+		std::shared_ptr<STIRAcquisitionData> sptr = std::move(sptr_ad->get_subset(v));
 		return newObjectHandle(sptr);
 	}
 	CATCH;
@@ -1248,7 +1248,7 @@ void* cSTIR_ImageData_move_to_scanner_centre(void* im_ptr, const void* acq_data_
 {
     try {
         STIRImageData& im = objectFromHandle<STIRImageData>(im_ptr);
-        PETAcquisitionData& ad = objectFromHandle<PETAcquisitionData>(acq_data_ptr);
+        STIRAcquisitionData& ad = objectFromHandle<STIRAcquisitionData>(acq_data_ptr);
         im.move_to_scanner_centre(ad);
 
         return static_cast<void*>(new DataHandle);
@@ -1261,7 +1261,7 @@ extern "C"
 void* cSTIR_imageFromAcquisitionData(void* ptr_ad)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_ad);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_ad);
 		shared_ptr<STIRImageData> sptr(new STIRImageData(*sptr_ad));
 		return newObjectHandle(sptr);
 	}
@@ -1272,7 +1272,7 @@ extern "C"
 void* cSTIR_imageFromAcquisitionDataAndNxNy(void* ptr_ad, int nx, int ny)
 {
 	try {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, ptr_ad);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, ptr_ad);
 		STIRImageData id(*sptr_ad);
 		int dim[3];
 		float vs[3];

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -97,7 +97,7 @@ wrongFloatParameterValue
 void*
 sirf::cSTIR_AcquisitionDataParameter(void* hp, const char* name)
 {
-	PETAcquisitionData& ad = objectFromHandle<PETAcquisitionData>(hp);
+	STIRAcquisitionData& ad = objectFromHandle<STIRAcquisitionData>(hp);
 	if (sirf::iequals(name, "tof_mash_factor"))
 		return dataHandle<int>(ad.get_tof_mash_factor());
 	else
@@ -136,7 +136,7 @@ sirf::cSTIR_setListmodeToSinogramsParameter(void* hp, const char* name, const vo
 	else if (sirf::iequals(name, "template_file"))
 		lm2s.set_template(charDataFromHandle(hv));
 	else if (sirf::iequals(name, "template"))
-		lm2s.set_template(objectFromHandle<PETAcquisitionData>(hv));
+		lm2s.set_template(objectFromHandle<STIRAcquisitionData>(hv));
 	else
 		return parameterNotFound(name, __FILE__, __LINE__);
 	return new DataHandle;
@@ -360,11 +360,11 @@ sirf::cSTIR_setAcquisitionModelParameter
 {
 	AcqMod3DF& am = objectFromHandle< AcqMod3DF >(hp);
 	if (sirf::iequals(name, "additive_term")) {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, hv);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, hv);
 		am.set_additive_term(sptr_ad);
 	}
 	else if (sirf::iequals(name, "background_term")) {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, hv);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, hv);
 		am.set_background_term(sptr_ad);
 	}
 	else if (sirf::iequals(name, "asm")) {
@@ -565,12 +565,12 @@ sirf::cSTIR_setScatterEstimatorParameter
 
     if (sirf::iequals(name, "setInput"))
     {
-        SPTR_FROM_HANDLE(PETAcquisitionData, sptr_pd, hv);
+        SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_pd, hv);
         obj.set_input_sptr(sptr_pd);
     }
     else if (sirf::iequals(name, "setRandoms"))
     {
-        SPTR_FROM_HANDLE(PETAcquisitionData, sptr_pd, hv);
+        SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_pd, hv);
         obj.set_background_sptr(sptr_pd);
     }
     else if (sirf::iequals(name, "setAttenuationImage"))
@@ -580,7 +580,7 @@ sirf::cSTIR_setScatterEstimatorParameter
     }
     else if (sirf::iequals(name, "setAttenuationCorrectionFactors"))
     {
-        SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, hv);
+        SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, hv);
         obj.set_attenuation_correction_factors_sptr(sptr_ad);
     }
     else if (sirf::iequals(name, "setASM"))
@@ -679,7 +679,7 @@ sirf::cSTIR_setPoissonLogLikelihoodWithLinearModelForMeanAndProjDataParameter
 	//else if (sirf::iequals(name, "max_segment_num_to_process"))
 	//	obj_fun.set_max_segment_num_toa_process(dataFromHandle<int>((void*)hv));
 	else if (sirf::iequals(name, "acquisition_data")) {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, hv);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, hv);
 		obj_fun.set_acquisition_data(sptr_ad);
 	}
 	else if (sirf::iequals(name, "acquisition_model")) {
@@ -715,7 +715,7 @@ sirf::cSTIR_setReconstructionParameter
 	if (sirf::iequals(name, "output_filename_prefix"))
 		recon.set_output_filename_prefix(charDataFromDataHandle(hv));
 	else if (sirf::iequals(name, "input_data")) {
-		SPTR_FROM_HANDLE(PETAcquisitionData, sptr_ad, hv);
+		SPTR_FROM_HANDLE(STIRAcquisitionData, sptr_ad, hv);
 		recon.set_input_data(sptr_ad->data());
 	}
 	else if (sirf::iequals(name, "disable_output")) {
@@ -890,7 +890,7 @@ sirf::cSTIR_setFBP2DParameter(DataHandle* hp, const char* name, const DataHandle
 	xSTIR_FBP2DReconstruction& recon =
 		objectFromHandle<xSTIR_FBP2DReconstruction >(hp);
 	if (sirf::iequals(name, "input")) {
-		PETAcquisitionData& acq_data = objectFromHandle<PETAcquisitionData>(hv);
+		STIRAcquisitionData& acq_data = objectFromHandle<STIRAcquisitionData>(hv);
 		recon.set_input(acq_data);
 	}
 	else if (sirf::iequals(name, "zoom")) {

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -145,22 +145,22 @@ namespace sirf {
 	storage mode (file/memory) selection.
 	*/
 
-	class PETAcquisitionData : public DataContainer {
+	class STIRAcquisitionData : public DataContainer {
 	public:
-		virtual ~PETAcquisitionData() {}
+		virtual ~STIRAcquisitionData() {}
 
 		// virtual constructors
-		virtual PETAcquisitionData* same_acquisition_data
+		virtual STIRAcquisitionData* same_acquisition_data
 			(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
 			stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info) const = 0;
-		virtual std::shared_ptr<PETAcquisitionData> new_acquisition_data() const = 0;
+		virtual std::shared_ptr<STIRAcquisitionData> new_acquisition_data() const = 0;
 
 		virtual bool is_complex() const
 		{
 			return false;
 		}
 
-		virtual std::unique_ptr<PETAcquisitionData> get_subset(const std::vector<int>& views) const = 0;
+		virtual std::unique_ptr<STIRAcquisitionData> get_subset(const std::vector<int>& views) const = 0;
 
 		//! rebin the data to lower resolution by adding
 		/*!
@@ -177,7 +177,7 @@ namespace sirf {
 		  \param max_in_segment_num_to_process by default all input data are used. If set to a non-negative
 		    number, it will remove the most oblique segments.
 		*/
-		std::shared_ptr<PETAcquisitionData> single_slice_rebinned_data(
+		std::shared_ptr<STIRAcquisitionData> single_slice_rebinned_data(
 			const int num_segments_to_combine,
 			const int num_views_to_combine = 1,
 			const int num_tang_poss_to_trim = 0,
@@ -194,7 +194,7 @@ namespace sirf {
 				max_in_segment_num_to_process,
 				num_tof_bins_to_combine
 			));
-			std::shared_ptr<PETAcquisitionData> 
+			std::shared_ptr<STIRAcquisitionData> 
 				sptr(same_acquisition_data
                                      (this->get_exam_info_sptr(), out_proj_data_info_sptr));
 			stir::SSRB(*sptr, *data(), do_normalisation);
@@ -210,7 +210,7 @@ namespace sirf {
 			}
 			return _storage_scheme;
 		}
-		static std::shared_ptr<PETAcquisitionData> storage_template()
+		static std::shared_ptr<STIRAcquisitionData> storage_template()
 		{
 			return _template;
 		}
@@ -230,18 +230,18 @@ namespace sirf {
 
 		// data import/export
 		virtual void fill(const float v) { data()->fill(v); }
-		virtual void fill(const PETAcquisitionData& ad)
+		virtual void fill(const STIRAcquisitionData& ad)
 		{
 			if (ad.is_empty())
-				THROW("The source of PETAcquisitionData::fill is empty");
+				THROW("The source of STIRAcquisitionData::fill is empty");
 			stir::shared_ptr<stir::ProjData> sptr = ad.data();
 			data()->fill(*sptr);
 		}
 		virtual void fill_from(const float* d) { data()->fill_from(d); }
 		virtual void copy_to(float* d) const { data()->copy_to(d); }
-		std::unique_ptr<PETAcquisitionData> clone() const
+		std::unique_ptr<STIRAcquisitionData> clone() const
 		{
-			return std::unique_ptr<PETAcquisitionData>(clone_impl());
+			return std::unique_ptr<STIRAcquisitionData>(clone_impl());
 		}
 
 		// data container methods
@@ -393,13 +393,13 @@ namespace sirf {
 
 	protected:
 		static std::string _storage_scheme;
-		static std::shared_ptr<PETAcquisitionData> _template;
+		static std::shared_ptr<STIRAcquisitionData> _template;
 		stir::shared_ptr<stir::ProjData> _data;
-		virtual PETAcquisitionData* clone_impl() const = 0;
-		PETAcquisitionData* clone_base() const
+		virtual STIRAcquisitionData* clone_impl() const = 0;
+		STIRAcquisitionData* clone_base() const
 		{
 			stir::shared_ptr<stir::ProjDataInfo> sptr_pdi = this->get_proj_data_info_sptr()->create_shared_clone();
-			PETAcquisitionData* ptr = 
+			STIRAcquisitionData* ptr = 
 				_template->same_acquisition_data(this->get_exam_info_sptr(), sptr_pdi);
 			if (!this->is_empty())
 				ptr->fill(*this);
@@ -413,42 +413,42 @@ namespace sirf {
 
 	/*!
 	\ingroup PET
-	\brief In-file implementation of PETAcquisitionData.
+	\brief In-file implementation of STIRAcquisitionData.
 
 	*/
 
-	class PETAcquisitionDataInFile : public PETAcquisitionData {
+	class STIRAcquisitionDataInFile : public STIRAcquisitionData {
 	public:
-		PETAcquisitionDataInFile() : _owns_file(false) {}
-		PETAcquisitionDataInFile(const char* filename) : _owns_file(false)
+		STIRAcquisitionDataInFile() : _owns_file(false) {}
+		STIRAcquisitionDataInFile(const char* filename) : _owns_file(false)
 		{
 			_data = stir::ProjData::read_from_file(filename);
 		}
-		PETAcquisitionDataInFile(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
+		STIRAcquisitionDataInFile(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
 			stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info)
 		{
 			_data.reset(new ProjDataFile
                                     (MAKE_SHARED<stir::ExamInfo>(*sptr_exam_info), sptr_proj_data_info,
                                      _filename = SIRFUtilities::scratch_file_name()));
 		}
-		PETAcquisitionDataInFile(const stir::ProjData& pd) : _owns_file(true)
+		STIRAcquisitionDataInFile(const stir::ProjData& pd) : _owns_file(true)
 		{
 			_data.reset(new ProjDataFile
 				(pd, _filename = SIRFUtilities::scratch_file_name()));
 		}
-		PETAcquisitionDataInFile
+		STIRAcquisitionDataInFile
 			(stir::shared_ptr<stir::ExamInfo> sptr_ei, std::string scanner_name,
 			int span = 1, int max_ring_diff = -1, int view_mash_factor = 1)
 		{
 			stir::shared_ptr<stir::ProjDataInfo> sptr_pdi =
-				PETAcquisitionData::proj_data_info_from_scanner
+				STIRAcquisitionData::proj_data_info_from_scanner
 				(scanner_name, span, max_ring_diff, view_mash_factor);
 			ProjDataFile* ptr = new ProjDataFile(sptr_ei, sptr_pdi,
 				_filename = SIRFUtilities::scratch_file_name());
 			ptr->fill(0.0f);
 			_data.reset(ptr);
 		}
-		PETAcquisitionDataInFile(std::unique_ptr<stir::ProjData> uptr_pd) : _owns_file(true)
+		STIRAcquisitionDataInFile(std::unique_ptr<stir::ProjData> uptr_pd) : _owns_file(true)
 		{
 //			auto *pd_ptr = dynamic_cast<stir::ProjDataInterfile*>(uptr_pd.get());
 			auto pd_ptr = dynamic_cast<stir::ProjDataInterfile*>(uptr_pd.get());
@@ -466,9 +466,9 @@ namespace sirf {
 				_data->fill(pd);
 			}
 		}
-		std::shared_ptr<PETAcquisitionData> new_acquisition_data(std::string filename)
+		std::shared_ptr<STIRAcquisitionData> new_acquisition_data(std::string filename)
 		{
-			std::shared_ptr<PETAcquisitionDataInFile> sptr_ad(new PETAcquisitionDataInFile);
+			std::shared_ptr<STIRAcquisitionDataInFile> sptr_ad(new STIRAcquisitionDataInFile);
 			sptr_ad->_data.reset(new ProjDataFile(*data(), filename, false));
 			return sptr_ad;
 		}
@@ -477,24 +477,24 @@ namespace sirf {
 			static bool initialized = false;
 			if (!initialized) {
 				_storage_scheme = "file";
-				_template.reset(new PETAcquisitionDataInFile());
+				_template.reset(new STIRAcquisitionDataInFile());
 				initialized = true;
-				PETAcquisitionData::storage_scheme();
+				STIRAcquisitionData::storage_scheme();
 			}
 		}
 		static void set_as_template()
 		{
 			init();
 			_storage_scheme = "file";
-			_template.reset(new PETAcquisitionDataInFile);
+			_template.reset(new STIRAcquisitionDataInFile);
 		}
 
-		virtual PETAcquisitionData* same_acquisition_data
+		virtual STIRAcquisitionData* same_acquisition_data
 			(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
 			stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info) const
 		{
-			PETAcquisitionData* ptr_ad =
-				new PETAcquisitionDataInFile(sptr_exam_info, sptr_proj_data_info);
+			STIRAcquisitionData* ptr_ad =
+				new STIRAcquisitionDataInFile(sptr_exam_info, sptr_proj_data_info);
 			return ptr_ad;
 		}
 		virtual ObjectHandle<DataContainer>* new_data_container_handle() const
@@ -506,58 +506,58 @@ namespace sirf {
 			return new ObjectHandle<DataContainer>
 				(std::shared_ptr<DataContainer>(ptr));
 		}
-		virtual std::shared_ptr<PETAcquisitionData> new_acquisition_data() const
+		virtual std::shared_ptr<STIRAcquisitionData> new_acquisition_data() const
 		{
 			init();
-			return std::shared_ptr < PETAcquisitionData >
+			return std::shared_ptr < STIRAcquisitionData >
 				(_template->same_acquisition_data(this->get_exam_info_sptr(),
 				this->get_proj_data_info_sptr()->create_shared_clone()));
 		}
-		virtual std::unique_ptr<PETAcquisitionData> get_subset(const std::vector<int>& views) const;
+		virtual std::unique_ptr<STIRAcquisitionData> get_subset(const std::vector<int>& views) const;
 
 	private:
 		bool _owns_file;
 		std::string _filename;
-		virtual PETAcquisitionDataInFile* clone_impl() const
+		virtual STIRAcquisitionDataInFile* clone_impl() const
 		{
 			init();
-			return (PETAcquisitionDataInFile*)clone_base();
+			return (STIRAcquisitionDataInFile*)clone_base();
 		}
 	};
 
 	/*!
 	\ingroup PET
-	\brief In-memory implementation of PETAcquisitionData.
+	\brief In-memory implementation of STIRAcquisitionData.
 
 	*/
 
-	class PETAcquisitionDataInMemory : public PETAcquisitionData {
+	class STIRAcquisitionDataInMemory : public STIRAcquisitionData {
 	public:
-		PETAcquisitionDataInMemory() {}
-		PETAcquisitionDataInMemory(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
+		STIRAcquisitionDataInMemory() {}
+		STIRAcquisitionDataInMemory(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
 			stir::shared_ptr<const stir::ProjDataInfo> sptr_proj_data_info)
 		{
 			_data = stir::shared_ptr<stir::ProjData>
 				(new stir::ProjDataInMemory(SPTR_WRAP(sptr_exam_info), SPTR_WRAP(sptr_proj_data_info)));
 		}
-		PETAcquisitionDataInMemory(const stir::ProjData& templ)
+		STIRAcquisitionDataInMemory(const stir::ProjData& templ)
 		{
 			_data = stir::shared_ptr<stir::ProjData>
 				(new stir::ProjDataInMemory(templ.get_exam_info_sptr(),
 					templ.get_proj_data_info_sptr()->create_shared_clone()));
 		}
-		PETAcquisitionDataInMemory
+		STIRAcquisitionDataInMemory
 			(stir::shared_ptr<stir::ExamInfo> sptr_ei, std::string scanner_name,
 			int span = 1, int max_ring_diff = -1, int view_mash_factor = 1)
 		{
 			stir::shared_ptr<stir::ProjDataInfo> sptr_pdi =
-				PETAcquisitionData::proj_data_info_from_scanner
+				STIRAcquisitionData::proj_data_info_from_scanner
 				(scanner_name, span, max_ring_diff, view_mash_factor);
 			stir::ProjDataInMemory* ptr = new stir::ProjDataInMemory(sptr_ei, sptr_pdi);
 			ptr->fill(0.0f);
 			_data.reset(ptr);
 		}
-		PETAcquisitionDataInMemory(std::unique_ptr<stir::ProjData> uptr_pd)
+		STIRAcquisitionDataInMemory(std::unique_ptr<stir::ProjData> uptr_pd)
 		{
 //			auto *pd_ptr = dynamic_cast<stir::ProjDataInMemory*>(uptr_pd.get());
 			auto pd_ptr = dynamic_cast<stir::ProjDataInMemory*>(uptr_pd.get());
@@ -573,8 +573,8 @@ namespace sirf {
 				_data->fill(pd);
 			}
 		}
-        /// Constructor for PETAcquisitionDataInMemory from filename
-        PETAcquisitionDataInMemory(const char* filename)
+        /// Constructor for STIRAcquisitionDataInMemory from filename
+        STIRAcquisitionDataInMemory(const char* filename)
         {
             auto pd_sptr = stir::ProjData::read_from_file(filename);
 			bool is_empty = false;
@@ -599,15 +599,15 @@ namespace sirf {
 		{
 			init();
 			_storage_scheme = "memory";
-			_template.reset(new PETAcquisitionDataInMemory);
+			_template.reset(new STIRAcquisitionDataInMemory);
 		}
 
-		virtual PETAcquisitionData* same_acquisition_data
+		virtual STIRAcquisitionData* same_acquisition_data
 			(stir::shared_ptr<const stir::ExamInfo> sptr_exam_info,
 			stir::shared_ptr<stir::ProjDataInfo> sptr_proj_data_info) const
 		{
-			PETAcquisitionData* ptr_ad =
-				new PETAcquisitionDataInMemory(sptr_exam_info, sptr_proj_data_info);
+			STIRAcquisitionData* ptr_ad =
+				new STIRAcquisitionDataInMemory(sptr_exam_info, sptr_proj_data_info);
 			return ptr_ad;
 		}
 		virtual ObjectHandle<DataContainer>* new_data_container_handle() const
@@ -619,15 +619,15 @@ namespace sirf {
 			return new ObjectHandle<DataContainer>
 				(std::shared_ptr<DataContainer>(ptr));
 		}
-		virtual std::shared_ptr<PETAcquisitionData> new_acquisition_data() const
+		virtual std::shared_ptr<STIRAcquisitionData> new_acquisition_data() const
 		{
 			init();
-			return std::shared_ptr < PETAcquisitionData >
+			return std::shared_ptr < STIRAcquisitionData >
 				(_template->same_acquisition_data
 				(this->get_exam_info_sptr(),
                                  this->get_proj_data_info_sptr()->create_shared_clone()));
 		}
-		virtual std::unique_ptr<PETAcquisitionData> get_subset(const std::vector<int>& views) const;
+		virtual std::unique_ptr<STIRAcquisitionData> get_subset(const std::vector<int>& views) const;
 
         /// fill with single value
         virtual void fill(const float v)
@@ -635,22 +635,22 @@ namespace sirf {
             stir::ProjDataInMemory *pd_ptr = dynamic_cast<stir::ProjDataInMemory*>(data().get());
             // If cast failed, fall back to general method
             if (is_null_ptr(pd_ptr))
-                return this->PETAcquisitionData::fill(v);
+                return this->STIRAcquisitionData::fill(v);
 
             // do it
             auto iter = pd_ptr->begin();
             while (iter != pd_ptr->end())
                 *iter++ = v;
         }
-        /// fill from another PETAcquisitionData
-        virtual void fill(const PETAcquisitionData& ad)
+        /// fill from another STIRAcquisitionData
+        virtual void fill(const STIRAcquisitionData& ad)
         {
-            // Can only do this if both are PETAcquisitionDataInMemory
+            // Can only do this if both are STIRAcquisitionDataInMemory
             stir::ProjDataInMemory *pd_ptr = dynamic_cast<stir::ProjDataInMemory*>(data().get());
             const stir::ProjDataInMemory *pd2_ptr = dynamic_cast<const stir::ProjDataInMemory*>(ad.data().get());
             // If either cast failed, fall back to general method
             if (is_null_ptr(pd_ptr) || is_null_ptr(pd2_ptr))
-                return this->PETAcquisitionData::fill(ad);
+                return this->STIRAcquisitionData::fill(ad);
 
             // do it
             auto iter = pd_ptr->begin();
@@ -664,7 +664,7 @@ namespace sirf {
             stir::ProjDataInMemory *pd_ptr = dynamic_cast<stir::ProjDataInMemory*>(data().get());
             // If cast failed, fall back to general method
             if (is_null_ptr(pd_ptr))
-                return this->PETAcquisitionData::fill_from(d);
+                return this->STIRAcquisitionData::fill_from(d);
 
             // do it
             auto iter = pd_ptr->begin();
@@ -677,7 +677,7 @@ namespace sirf {
             const stir::ProjDataInMemory *pd_ptr = dynamic_cast<const stir::ProjDataInMemory*>(data().get());
             // If cast failed, fall back to general method
             if (is_null_ptr(pd_ptr))
-                return this->PETAcquisitionData::copy_to(d);
+                return this->STIRAcquisitionData::copy_to(d);
 
             // do it
             auto iter = pd_ptr->begin();
@@ -689,7 +689,7 @@ namespace sirf {
             const stir::ProjDataInMemory *pd_ptr = dynamic_cast<const stir::ProjDataInMemory*>(data().get());
             // If cast failed, fall back to general method
             if (is_null_ptr(pd_ptr))
-                return this->PETAcquisitionData::norm();
+                return this->STIRAcquisitionData::norm();
 
             // do it
             double t = 0.0;
@@ -700,13 +700,13 @@ namespace sirf {
         }
         virtual void dot(const DataContainer& a_x, void* ptr) const
         {
-            auto x = dynamic_cast<const PETAcquisitionData*>(&a_x);
-            // Can only do this if both are PETAcquisitionDataInMemory
+            auto x = dynamic_cast<const STIRAcquisitionData*>(&a_x);
+            // Can only do this if both are STIRAcquisitionDataInMemory
             stir::ProjDataInMemory *pd_ptr = dynamic_cast<stir::ProjDataInMemory*>(data().get());
             const stir::ProjDataInMemory *pd2_ptr = dynamic_cast<const stir::ProjDataInMemory*>(x->data().get());
             // If either cast failed, fall back to general method
             if (is_null_ptr(pd_ptr) || is_null_ptr(pd2_ptr))
-                return this->PETAcquisitionData::dot(a_x,ptr);
+                return this->STIRAcquisitionData::dot(a_x,ptr);
 
             // do it
             double t = 0.0;
@@ -720,17 +720,17 @@ namespace sirf {
         }
         virtual void multiply(const DataContainer& x, const DataContainer& y)
         {
-            auto a_x = dynamic_cast<const PETAcquisitionData*>(&x);
-            auto a_y = dynamic_cast<const PETAcquisitionData*>(&y);
+            auto a_x = dynamic_cast<const STIRAcquisitionData*>(&x);
+            auto a_y = dynamic_cast<const STIRAcquisitionData*>(&y);
 
-            // Can only do this if all are PETAcquisitionDataInMemory
+            // Can only do this if all are STIRAcquisitionDataInMemory
             auto *pd_ptr   = dynamic_cast<stir::ProjDataInMemory*>(data().get());
             auto *pd_x_ptr = dynamic_cast<const stir::ProjDataInMemory*>(a_x->data().get());
             auto *pd_y_ptr = dynamic_cast<const stir::ProjDataInMemory*>(a_y->data().get());
 
             // If either cast failed, fall back to general method
             if (is_null_ptr(pd_ptr) || is_null_ptr(pd_x_ptr) || is_null_ptr(pd_x_ptr))
-                return this->PETAcquisitionData::multiply(x,y);
+                return this->STIRAcquisitionData::multiply(x,y);
 
             // do it
             auto iter = pd_ptr->begin();
@@ -741,17 +741,17 @@ namespace sirf {
         }
         virtual void divide(const DataContainer& x, const DataContainer& y)
         {
-            auto a_x = dynamic_cast<const PETAcquisitionData*>(&x);
-            auto a_y = dynamic_cast<const PETAcquisitionData*>(&y);
+            auto a_x = dynamic_cast<const STIRAcquisitionData*>(&x);
+            auto a_y = dynamic_cast<const STIRAcquisitionData*>(&y);
 
-            // Can only do this if all are PETAcquisitionDataInMemory
+            // Can only do this if all are STIRAcquisitionDataInMemory
             auto *pd_ptr   = dynamic_cast<stir::ProjDataInMemory*>(data().get());
             auto *pd_x_ptr = dynamic_cast<const stir::ProjDataInMemory*>(a_x->data().get());
             auto *pd_y_ptr = dynamic_cast<const stir::ProjDataInMemory*>(a_y->data().get());
 
             // If either cast failed, fall back to general method
             if (is_null_ptr(pd_ptr) || is_null_ptr(pd_x_ptr) || is_null_ptr(pd_x_ptr))
-                return this->PETAcquisitionData::divide(x,y);
+                return this->STIRAcquisitionData::divide(x,y);
 
             // do it
             auto iter = pd_ptr->begin();
@@ -762,12 +762,19 @@ namespace sirf {
         }
 
 	private:
-		virtual PETAcquisitionDataInMemory* clone_impl() const
+		virtual STIRAcquisitionDataInMemory* clone_impl() const
 		{
 			init();
-			return (PETAcquisitionDataInMemory*)clone_base();
+			return (STIRAcquisitionDataInMemory*)clone_base();
 		}
 	};
+
+	///
+	///  Backward compatibility - to be removed in SIRF 4
+	///
+	typedef STIRAcquisitionData PETAcquisitionData;
+	typedef STIRAcquisitionDataInFile PETAcquisitionDataInFile;
+	typedef STIRAcquisitionDataInMemory PETAcquisitionDataInMemory;
 
 	typedef Image3DF::full_iterator Image3DFIterator;
 	typedef Image3DF::const_full_iterator Image3DFIterator_const;
@@ -885,7 +892,7 @@ namespace sirf {
 			_data.reset(image.data().clone());
             this->set_up_geom_info();
 		}
-		STIRImageData(const PETAcquisitionData& ad)
+		STIRImageData(const STIRAcquisitionData& ad)
 		{
                   _data.reset(new Voxels3DF(MAKE_SHARED<stir::ExamInfo>(*ad.get_exam_info_sptr()),*ad.get_proj_data_info_sptr()));
             this->set_up_geom_info();
@@ -1111,7 +1118,7 @@ namespace sirf {
 
         /// Move to scanner centre. The acquisition needs to be supplied such that in the future,
         /// bed offset etc can be taken into account.
-        void move_to_scanner_centre(const PETAcquisitionData &);
+        void move_to_scanner_centre(const STIRAcquisitionData &);
 
         /// Populate the geometrical info metadata (from the image's own metadata)
         virtual void set_up_geom_info();

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -47,7 +47,6 @@ limitations under the License.
 #include "sirf/common/ANumRef.h"
 #include "sirf/common/ImageData.h"
 #include "sirf/common/GeometricalInfo.h"
-#include "sirf/common/version.h"
 #include "stir/ZoomOptions.h"
 
 #if STIR_VERSION < 050000

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -47,6 +47,7 @@ limitations under the License.
 #include "sirf/common/ANumRef.h"
 #include "sirf/common/ImageData.h"
 #include "sirf/common/GeometricalInfo.h"
+#include "sirf/common/version.h"
 #include "stir/ZoomOptions.h"
 
 #if STIR_VERSION < 050000
@@ -769,12 +770,14 @@ namespace sirf {
 		}
 	};
 
+#if SIRF_VERSION_MAJOR < 4
 	///
 	///  Backward compatibility - to be removed in SIRF 4
 	///
 	typedef STIRAcquisitionData PETAcquisitionData;
 	typedef STIRAcquisitionDataInFile PETAcquisitionDataInFile;
 	typedef STIRAcquisitionDataInMemory PETAcquisitionDataInMemory;
+#endif
 
 	typedef Image3DF::full_iterator Image3DFIterator;
 	typedef Image3DF::const_full_iterator Image3DFIterator_const;

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -52,11 +52,11 @@ namespace sirf {
 \brief Listmode-to-sinograms converter.
 
 This class reads list mode data and produces corresponding *sinograms*,
-i.e. histogrammed data in the format of PETAcquisitionData.
+i.e. histogrammed data in the format of STIRAcquisitionData.
 
 It has 2 main functions:
 - process() can be used to read prompts and/or delayed coincidences to produce a single
-PETAcquisitionData. 2 variables decide what done with 3 possible cases:
+STIRAcquisitionData. 2 variables decide what done with 3 possible cases:
 - `store_prompts`=`true`, `store_delayeds`=`false`: only prompts are stored
 - `store_prompts`=`false`, `store_delayeds`=`true`: only delayeds are stored
 - `store_prompts`=`true`, `store_delayeds`=`true`: prompts-delayeds are stored
@@ -123,10 +123,10 @@ The actual algorithm is described in
 		}
 		void set_template(std::string proj_data_file)
 		{
-                        PETAcquisitionDataInFile acq_data_template(proj_data_file.c_str());
+                        STIRAcquisitionDataInFile acq_data_template(proj_data_file.c_str());
                         set_template(acq_data_template);
 		}
-		void set_template(const PETAcquisitionData& acq_data_template)
+		void set_template(const STIRAcquisitionData& acq_data_template)
 		{
                         template_proj_data_info_ptr =
                           acq_data_template.get_proj_data_info_sptr()->create_shared_clone();
@@ -186,7 +186,7 @@ The actual algorithm is described in
                         stir::shared_ptr<ProjDataInfo> temp_proj_data_info_sptr(template_proj_data_info_ptr->clone());
 			temp_proj_data_info_sptr->set_bed_position_horizontal(h);
 			temp_proj_data_info_sptr->set_bed_position_vertical(v);
-			randoms_sptr.reset(new PETAcquisitionDataInMemory(exam_info_sptr_, temp_proj_data_info_sptr));
+			randoms_sptr.reset(new STIRAcquisitionDataInMemory(exam_info_sptr_, temp_proj_data_info_sptr));
 
 			return stir::Succeeded::yes;
 		}
@@ -196,13 +196,13 @@ The actual algorithm is described in
 			std::string filename = output_filename_prefix + "_randoms" + "_f1g1d0b0.hs";
 			randoms_sptr->write(filename.c_str());
 		}
-		std::shared_ptr<PETAcquisitionData> get_output()
+		std::shared_ptr<STIRAcquisitionData> get_output()
 		{
 			std::string filename = output_filename_prefix + "_f1g1d0b0.hs";
-			return std::shared_ptr<PETAcquisitionData>
-				(new PETAcquisitionDataInFile(filename.c_str()));
+			return std::shared_ptr<STIRAcquisitionData>
+				(new STIRAcquisitionDataInFile(filename.c_str()));
 		}
-		std::shared_ptr<PETAcquisitionData> get_randoms_sptr()
+		std::shared_ptr<STIRAcquisitionData> get_randoms_sptr()
 		{
 			return randoms_sptr;
 		}
@@ -223,7 +223,7 @@ The actual algorithm is described in
 		stir::shared_ptr<ProjDataInfo> proj_data_info_sptr_;
 		stir::shared_ptr<std::vector<stir::Array<2, float> > > fan_sums_sptr;
 		stir::shared_ptr<stir::DetectorEfficiencies> det_eff_sptr;
-		std::shared_ptr<PETAcquisitionData> randoms_sptr;
+		std::shared_ptr<STIRAcquisitionData> randoms_sptr;
 		void compute_fan_sums_(bool prompt_fansum = false);
 		int compute_singles_();
 //		void estimate_randoms_();
@@ -242,7 +242,7 @@ The actual algorithm is described in
 	public:
 		PETAcquisitionSensitivityModel() {}
 		// create from bin (detector pair) efficiencies sinograms
-		PETAcquisitionSensitivityModel(PETAcquisitionData& ad);
+		PETAcquisitionSensitivityModel(STIRAcquisitionData& ad);
 		// create from ECAT8
 		PETAcquisitionSensitivityModel(std::string filename);
 		// chain two normalizations
@@ -256,21 +256,21 @@ The actual algorithm is described in
 			const stir::shared_ptr<stir::ProjDataInfo>&);
 
 		// multiply by bin efficiencies
-		virtual void unnormalise(PETAcquisitionData& ad) const;
+		virtual void unnormalise(STIRAcquisitionData& ad) const;
 		// divide by bin efficiencies
-		virtual void normalise(PETAcquisitionData& ad) const;
+		virtual void normalise(STIRAcquisitionData& ad) const;
 		// same as apply, but returns new data rather than changes old one
-		std::shared_ptr<PETAcquisitionData> forward(const PETAcquisitionData& ad) const
+		std::shared_ptr<STIRAcquisitionData> forward(const STIRAcquisitionData& ad) const
 		{
-			std::shared_ptr<PETAcquisitionData> sptr_ad = ad.new_acquisition_data();
+			std::shared_ptr<STIRAcquisitionData> sptr_ad = ad.new_acquisition_data();
 			sptr_ad->fill(ad);
 			this->unnormalise(*sptr_ad);
 			return sptr_ad;
 		}
 		// same as undo, but returns new data rather than changes old one
-		std::shared_ptr<PETAcquisitionData> invert(const PETAcquisitionData& ad) const
+		std::shared_ptr<STIRAcquisitionData> invert(const STIRAcquisitionData& ad) const
 		{
-			std::shared_ptr<PETAcquisitionData> sptr_ad = ad.new_acquisition_data();
+			std::shared_ptr<STIRAcquisitionData> sptr_ad = ad.new_acquisition_data();
 			sptr_ad->fill(ad);
 			this->normalise(*sptr_ad);
 			return sptr_ad;
@@ -348,7 +348,7 @@ The actual algorithm is described in
 		\brief Class for the product of backward and forward projectors of a PET acquisition model.
 
 		For a given STIRImageData object x, computes B(F(x)), where F(x) is the linear part S G of
-		the forward projection of x, and B(y) is the backprojection of PETAcquisitionData object y.
+		the forward projection of x, and B(y) is the backprojection of STIRAcquisitionData object y.
 		*/
 		class BFOperator : public Operator<STIRImageData> {
 		public:
@@ -363,7 +363,7 @@ The actual algorithm is described in
 			}
 			virtual std::shared_ptr<STIRImageData> apply(STIRImageData& image_data)
 			{
-				std::shared_ptr<PETAcquisitionData> sptr_fwd =
+				std::shared_ptr<STIRAcquisitionData> sptr_fwd =
 					sptr_am_->forward(image_data, sub_num_, num_sub_); // , true);
 				std::shared_ptr<STIRImageData> sptr_bwd =
 					sptr_am_->backward(*sptr_fwd, sub_num_, num_sub_);
@@ -404,23 +404,23 @@ The actual algorithm is described in
 		{
 			return sptr_projectors_;
 		}
-		void set_additive_term(std::shared_ptr<PETAcquisitionData> sptr)
+		void set_additive_term(std::shared_ptr<STIRAcquisitionData> sptr)
 		{
 			sptr_add_ = sptr;
 		}
-		std::shared_ptr<const PETAcquisitionData> additive_term_sptr() const
+		std::shared_ptr<const STIRAcquisitionData> additive_term_sptr() const
 		{
 			return sptr_add_;
 		}
-		void set_background_term(std::shared_ptr<PETAcquisitionData> sptr)
+		void set_background_term(std::shared_ptr<STIRAcquisitionData> sptr)
 		{
 			sptr_background_ = sptr;
 		}
-		std::shared_ptr<const PETAcquisitionData> background_term_sptr() const
+		std::shared_ptr<const STIRAcquisitionData> background_term_sptr() const
 		{
 			return sptr_background_;
 		}
-		std::shared_ptr<const PETAcquisitionData> acq_template_sptr() const
+		std::shared_ptr<const STIRAcquisitionData> acq_template_sptr() const
 		{
 			return sptr_acq_template_;
 		}
@@ -440,8 +440,8 @@ The actual algorithm is described in
 			return sptr;
 			//return sptr_normalisation_;
 		}
-		//void set_bin_efficiency(shared_ptr<PETAcquisitionData> sptr_data);
-		//void set_normalisation(shared_ptr<PETAcquisitionData> sptr_data)
+		//void set_bin_efficiency(shared_ptr<STIRAcquisitionData> sptr_data);
+		//void set_normalisation(shared_ptr<STIRAcquisitionData> sptr_data)
 		//{
 		//	sptr_normalisation_.reset(new stir::BinNormalisationFromProjData(*sptr_data));
 		//}
@@ -483,13 +483,13 @@ The actual algorithm is described in
 		}
 
 		virtual void set_up(
-			std::shared_ptr<PETAcquisitionData> sptr_acq,
+			std::shared_ptr<STIRAcquisitionData> sptr_acq,
 			std::shared_ptr<STIRImageData> sptr_image);
 
 		/*! \brief computes and returns a subset of forward-projected data
-		\see forward(PETAcquisitionData&, const STIRImageData&,, int, int, bool, bool)
+		\see forward(STIRAcquisitionData&, const STIRImageData&,, int, int, bool, bool)
 		*/
-		std::shared_ptr<PETAcquisitionData>
+		std::shared_ptr<STIRAcquisitionData>
 			forward(const STIRImageData& image,
 			int subset_num = 0, int num_subsets = 1, bool do_linear_only = false) const;
 		/*! \brief replaces a subset of acquisition data with forward-projected data
@@ -502,22 +502,22 @@ The actual algorithm is described in
 								specified by subset_num
 		\param[in] linear		use only linear part of the acquisition model (no constant terms)
 		*/
-		void forward(PETAcquisitionData& acq_data, const STIRImageData& image,
+		void forward(STIRAcquisitionData& acq_data, const STIRImageData& image,
 			int subset_num, int num_subsets, bool zero = false, bool do_linear_only = false) const;
 
 		// computes and returns back-projected subset of acquisition data 
-		std::shared_ptr<STIRImageData> backward(PETAcquisitionData& ad,
+		std::shared_ptr<STIRImageData> backward(STIRAcquisitionData& ad,
 			int subset_num = 0, int num_subsets = 1) const;
 		// puts back-projected subset of acquisition data into image 
-		void backward(STIRImageData& image, PETAcquisitionData& ad,
+		void backward(STIRImageData& image, STIRAcquisitionData& ad,
 			int subset_num = 0, int num_subsets = 1) const;
 
 	protected:
 		stir::shared_ptr<stir::ProjectorByBinPair> sptr_projectors_;
-		std::shared_ptr<PETAcquisitionData> sptr_acq_template_;
+		std::shared_ptr<STIRAcquisitionData> sptr_acq_template_;
 		std::shared_ptr<STIRImageData> sptr_image_template_;
-		std::shared_ptr<PETAcquisitionData> sptr_add_;
-		std::shared_ptr<PETAcquisitionData> sptr_background_;
+		std::shared_ptr<STIRAcquisitionData> sptr_add_;
+		std::shared_ptr<STIRAcquisitionData> sptr_background_;
 		std::shared_ptr<PETAcquisitionSensitivityModel> sptr_asm_;
 		//shared_ptr<stir::BinNormalisation> sptr_normalisation_;
 	};
@@ -545,7 +545,7 @@ The actual algorithm is described in
         stir::SingleScatterSimulation(filename)
         {}
 
-        void set_up(std::shared_ptr<const PETAcquisitionData> sptr_acq_template,
+        void set_up(std::shared_ptr<const STIRAcquisitionData> sptr_acq_template,
                     std::shared_ptr<const STIRImageData> sptr_act_image_template)
           {
             this->sptr_acq_template_ = sptr_acq_template;
@@ -591,17 +591,17 @@ The actual algorithm is described in
 #endif
         }
 
-        std::shared_ptr<PETAcquisitionData> forward(const STIRImageData& activity_img) /*TODO CONST*/
+        std::shared_ptr<STIRAcquisitionData> forward(const STIRImageData& activity_img) /*TODO CONST*/
           {
             if (!sptr_acq_template_.get())
               THROW("Fatal error in PETSingleScatterSimulator::forward: acquisition template not set");
-            std::shared_ptr<PETAcquisitionData> sptr_ad =
+            std::shared_ptr<STIRAcquisitionData> sptr_ad =
               sptr_acq_template_->new_acquisition_data();
             this->forward( *sptr_ad, activity_img);
             return sptr_ad;
           }
 
-        void forward(PETAcquisitionData& ad, const STIRImageData& activity_img) /* TODO CONST*/
+        void forward(STIRAcquisitionData& ad, const STIRImageData& activity_img) /* TODO CONST*/
           {
             stir::shared_ptr<ProjData> sptr_fd = ad.data();
             this->set_output_proj_data_sptr(sptr_fd);
@@ -610,7 +610,7 @@ The actual algorithm is described in
           }
 
     protected:
-        std::shared_ptr<const PETAcquisitionData> sptr_acq_template_;
+        std::shared_ptr<const STIRAcquisitionData> sptr_acq_template_;
 
     };
 
@@ -652,12 +652,12 @@ The actual algorithm is described in
         {}
 
         //! Set the input data
-        void set_input_sptr(std::shared_ptr<const PETAcquisitionData> arg)
+        void set_input_sptr(std::shared_ptr<const STIRAcquisitionData> arg)
         {
             stir::ScatterEstimation::set_input_proj_data_sptr(arg->data());
         }
         //! Set attenuation correction factors as acq_data
-        void set_attenuation_correction_factors_sptr(std::shared_ptr<const PETAcquisitionData> arg)
+        void set_attenuation_correction_factors_sptr(std::shared_ptr<const STIRAcquisitionData> arg)
         {
           stir::ScatterEstimation::set_attenuation_correction_proj_data_sptr(arg->data());
         }
@@ -667,7 +667,7 @@ The actual algorithm is described in
           stir::ScatterEstimation::set_normalisation_sptr(arg->data());
         }
         //! Set the background data (normally equal to the randoms in PET)
-        void set_background_sptr(std::shared_ptr<const PETAcquisitionData> arg)
+        void set_background_sptr(std::shared_ptr<const STIRAcquisitionData> arg)
         {
             stir::ScatterEstimation::set_background_proj_data_sptr(arg->data());
         }
@@ -706,7 +706,7 @@ The actual algorithm is described in
           return stir::ScatterEstimation::get_num_iterations();
         }
 
-        std::shared_ptr<PETAcquisitionData> get_scatter_estimate(int est_num = -1) const
+        std::shared_ptr<STIRAcquisitionData> get_scatter_estimate(int est_num = -1) const
         {
             if (est_num == -1) // Get the last one
                 est_num = num_scatter_iterations;
@@ -716,17 +716,17 @@ The actual algorithm is described in
             if (output_scatter_estimate_prefix.empty())
               THROW("output_scatter_estimate_prefix not set, so scatter estimates were not saved to file.");
             const std::string filename = output_scatter_estimate_prefix + "_" + std::to_string(est_num) + ".hs";
-            return std::make_shared<PETAcquisitionDataInFile>(filename.c_str());
+            return std::make_shared<STIRAcquisitionDataInFile>(filename.c_str());
         }
 
         //! get last scatter estimate
-        std::shared_ptr<PETAcquisitionData> get_output() const
+        std::shared_ptr<STIRAcquisitionData> get_output() const
           {
             auto stir_proj_data_sptr = stir::ScatterEstimation::get_output();
             if (!stir_proj_data_sptr)
               THROW("output not yet computed");
-            std::shared_ptr<PETAcquisitionData> sptr_acq_data
-              (PETAcquisitionData::storage_template()->same_acquisition_data(stir_proj_data_sptr->get_exam_info_sptr(),
+            std::shared_ptr<STIRAcquisitionData> sptr_acq_data
+              (STIRAcquisitionData::storage_template()->same_acquisition_data(stir_proj_data_sptr->get_exam_info_sptr(),
                                                                              stir_proj_data_sptr->get_proj_data_info_sptr()->create_shared_clone()));
             sptr_acq_data->data()->fill(*stir_proj_data_sptr);
             return sptr_acq_data;
@@ -795,7 +795,7 @@ The actual algorithm is described in
 			//	get_proj_matrix_sptr();
 		}
 		virtual	void set_up(
-			std::shared_ptr<PETAcquisitionData> sptr_acq,
+			std::shared_ptr<STIRAcquisitionData> sptr_acq,
 			std::shared_ptr<STIRImageData> sptr_image)
 		{
 			if (!sptr_matrix_.get())
@@ -936,9 +936,9 @@ The actual algorithm is described in
 	public:
 		PETAttenuationModel(STIRImageData& id, PETAcquisitionModel& am);
 		// multiply by bin efficiencies
-		virtual void unnormalise(PETAcquisitionData& ad) const;
+		virtual void unnormalise(STIRAcquisitionData& ad) const;
 		// divide by bin efficiencies
-		virtual void normalise(PETAcquisitionData& ad) const;
+		virtual void normalise(STIRAcquisitionData& ad) const;
 	protected:
 		stir::shared_ptr<stir::ForwardProjectorByBin> sptr_forw_projector_;
 	};
@@ -989,7 +989,7 @@ The actual algorithm is described in
 		void set_input_file(const char* filename) {
 			input_filename = filename;
 		}
-		void set_acquisition_data(std::shared_ptr<PETAcquisitionData> sptr)
+		void set_acquisition_data(std::shared_ptr<STIRAcquisitionData> sptr)
 		{
 			sptr_ad_ = sptr;
 			set_proj_data_sptr(sptr->data());
@@ -1009,7 +1009,7 @@ The actual algorithm is described in
 			}
 			else {
 				auto sptr_b = am.background_term_sptr();
-				stir::shared_ptr<PETAcquisitionData> sptr;
+				stir::shared_ptr<STIRAcquisitionData> sptr;
 				if (have_asm)
 					sptr = sptr_asm->invert(*sptr_b);
 				else
@@ -1029,7 +1029,7 @@ The actual algorithm is described in
 			return sptr_am_;
 		}
 	private:
-		std::shared_ptr<PETAcquisitionData> sptr_ad_;
+		std::shared_ptr<STIRAcquisitionData> sptr_ad_;
 		std::shared_ptr<AcqMod3DF> sptr_am_;
 	};
 
@@ -1092,7 +1092,7 @@ The actual algorithm is described in
 		{
 			_is_set_up = false;
 		}
-		void set_input(const PETAcquisitionData& acq)
+		void set_input(const STIRAcquisitionData& acq)
 		{
 			set_input_data(acq.data());
 		}

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -30,11 +30,11 @@ using namespace sirf;
 //#define SIRF_DYNAMIC_CAST(T, X, Y) T& X = (T&)Y
 #define SIRF_DYNAMIC_CAST(T, X, Y) T& X = dynamic_cast<T&>(Y)
 
-std::string PETAcquisitionData::_storage_scheme;
-std::shared_ptr<PETAcquisitionData> PETAcquisitionData::_template;
+std::string STIRAcquisitionData::_storage_scheme;
+std::shared_ptr<STIRAcquisitionData> STIRAcquisitionData::_template;
 
 float
-PETAcquisitionData::norm() const
+STIRAcquisitionData::norm() const
 {
 	double t = 0.0;
 	for (int s = 0; s <= get_max_segment_num(); ++s)
@@ -57,10 +57,10 @@ PETAcquisitionData::norm() const
 }
 
 void
-PETAcquisitionData::dot(const DataContainer& a_x, void* ptr) const
+STIRAcquisitionData::dot(const DataContainer& a_x, void* ptr) const
 {
-	//PETAcquisitionData& x = (PETAcquisitionData&)a_x;
-	SIRF_DYNAMIC_CAST(const PETAcquisitionData, x, a_x);
+	//STIRAcquisitionData& x = (STIRAcquisitionData&)a_x;
+	SIRF_DYNAMIC_CAST(const STIRAcquisitionData, x, a_x);
 	int n = get_max_segment_num();
 	int nx = x.get_max_segment_num();
 	double t = 0;
@@ -89,17 +89,17 @@ PETAcquisitionData::dot(const DataContainer& a_x, void* ptr) const
 }
 
 void
-PETAcquisitionData::axpby(
+STIRAcquisitionData::axpby(
 const void* ptr_a, const DataContainer& a_x,
 const void* ptr_b, const DataContainer& a_y
 )
 {
 	//Add deprecation warning
-    PETAcquisitionData::xapyb(a_x, ptr_a, a_y, ptr_b);
+    STIRAcquisitionData::xapyb(a_x, ptr_a, a_y, ptr_b);
 }
 
 void
-PETAcquisitionData::xapyb(
+STIRAcquisitionData::xapyb(
 const DataContainer& a_x, const void* ptr_a,
 const DataContainer& a_y, const void* ptr_b
 )
@@ -107,46 +107,46 @@ const DataContainer& a_y, const void* ptr_b
     // Cast to correct types
     float a = *(float*)ptr_a;
     float b = *(float*)ptr_b;
-    auto x = dynamic_cast<const PETAcquisitionData*>(&a_x);
-    auto y = dynamic_cast<const PETAcquisitionData*>(&a_y);
+    auto x = dynamic_cast<const STIRAcquisitionData*>(&a_x);
+    auto y = dynamic_cast<const STIRAcquisitionData*>(&a_y);
 
     if (is_null_ptr(x) || is_null_ptr(x->data()) ||
             is_null_ptr(y) || is_null_ptr(y->data()))
-        throw std::runtime_error("PETAcquisitionData::xapyb: At least one argument is not"
-                                 "PETAcquisitionData or is not initialised.");
+        throw std::runtime_error("STIRAcquisitionData::xapyb: At least one argument is not"
+                                 "STIRAcquisitionData or is not initialised.");
 
     // Call STIR's xapyb
     data()->xapyb(*x->data(), a, *y->data(), b);
 }
 
 void
-PETAcquisitionData::xapyb(
+STIRAcquisitionData::xapyb(
 const DataContainer& a_x, const DataContainer& a_a,
 const DataContainer& a_y, const DataContainer& a_b
 )
 {
     // Cast to correct types
-    auto a = dynamic_cast<const PETAcquisitionData*>(&a_a);
-    auto b = dynamic_cast<const PETAcquisitionData*>(&a_b);
-    auto x = dynamic_cast<const PETAcquisitionData*>(&a_x);
-    auto y = dynamic_cast<const PETAcquisitionData*>(&a_y);
+    auto a = dynamic_cast<const STIRAcquisitionData*>(&a_a);
+    auto b = dynamic_cast<const STIRAcquisitionData*>(&a_b);
+    auto x = dynamic_cast<const STIRAcquisitionData*>(&a_x);
+    auto y = dynamic_cast<const STIRAcquisitionData*>(&a_y);
 
     if (is_null_ptr(x) || is_null_ptr(x->data()) ||
             is_null_ptr(y) || is_null_ptr(y->data()) ||
             is_null_ptr(a) || is_null_ptr(a->data()) ||
             is_null_ptr(b) || is_null_ptr(b->data()))
-        throw std::runtime_error("PETAcquisitionData::xapyb: At least one argument is not"
-                                 "PETAcquisitionData or is not initialised.");
+        throw std::runtime_error("STIRAcquisitionData::xapyb: At least one argument is not"
+                                 "STIRAcquisitionData or is not initialised.");
 
     // Call STIR's xapyb
     data()->xapyb(*x->data(), *a->data(), *y->data(), *b->data());
 }
 
 void
-PETAcquisitionData::inv(float amin, const DataContainer& a_x)
+STIRAcquisitionData::inv(float amin, const DataContainer& a_x)
 {
-	//PETAcquisitionData& x = (PETAcquisitionData&)a_x;
-	SIRF_DYNAMIC_CAST(const PETAcquisitionData, x, a_x);
+	//STIRAcquisitionData& x = (STIRAcquisitionData&)a_x;
+	SIRF_DYNAMIC_CAST(const STIRAcquisitionData, x, a_x);
 	int n = get_max_segment_num();
 	int nx = x.get_max_segment_num();
 	for (int s = 0; s <= n && s <= nx; ++s)
@@ -176,14 +176,14 @@ PETAcquisitionData::inv(float amin, const DataContainer& a_x)
 }
 
 void
-PETAcquisitionData::binary_op_(
+STIRAcquisitionData::binary_op_(
 	const DataContainer& a_x,
 	const DataContainer& a_y,
 	int job
 )
 {
-	SIRF_DYNAMIC_CAST(const PETAcquisitionData, x, a_x);
-	SIRF_DYNAMIC_CAST(const PETAcquisitionData, y, a_y);
+	SIRF_DYNAMIC_CAST(const STIRAcquisitionData, x, a_x);
+	SIRF_DYNAMIC_CAST(const STIRAcquisitionData, y, a_y);
 	int n = get_max_segment_num();
 	int nx = x.get_max_segment_num();
 	int ny = y.get_max_segment_num();
@@ -245,25 +245,25 @@ PETAcquisitionData::binary_op_(
 	}
 }
 
-std::unique_ptr<PETAcquisitionData>
-PETAcquisitionDataInFile::get_subset(const std::vector<int>& views) const
+std::unique_ptr<STIRAcquisitionData>
+STIRAcquisitionDataInFile::get_subset(const std::vector<int>& views) const
 {
-	auto ptr_ad = new PETAcquisitionDataInFile(std::move(_data->get_subset(views)));
-//	auto ptr_ad = new PETAcquisitionDataInMemory(std::move(_data->get_subset(views)));
-	return std::unique_ptr<PETAcquisitionData>(ptr_ad);
+	auto ptr_ad = new STIRAcquisitionDataInFile(std::move(_data->get_subset(views)));
+//	auto ptr_ad = new STIRAcquisitionDataInMemory(std::move(_data->get_subset(views)));
+	return std::unique_ptr<STIRAcquisitionData>(ptr_ad);
 }
 
-std::unique_ptr<PETAcquisitionData>
-PETAcquisitionDataInMemory::get_subset(const std::vector<int>& views) const
+std::unique_ptr<STIRAcquisitionData>
+STIRAcquisitionDataInMemory::get_subset(const std::vector<int>& views) const
 {
-	auto ptr_ad = new PETAcquisitionDataInMemory(std::move(_data->get_subset(views)));
-	return std::unique_ptr<PETAcquisitionData>(ptr_ad);
+	auto ptr_ad = new STIRAcquisitionDataInMemory(std::move(_data->get_subset(views)));
+	return std::unique_ptr<STIRAcquisitionData>(ptr_ad);
 }
 
 void
-PETAcquisitionDataInMemory::init()
+STIRAcquisitionDataInMemory::init()
 {
-	PETAcquisitionDataInFile::init();
+	STIRAcquisitionDataInFile::init();
 }
 
 
@@ -611,7 +611,7 @@ zoom_image(const Coord3DF &zooms, const Coord3DF &offsets_in_mm,
 
 void
 STIRImageData::
-move_to_scanner_centre(const PETAcquisitionData &)
+move_to_scanner_centre(const STIRAcquisitionData &)
 {
     this->_data->set_origin(CartesianCoordinate3D<float>{0.f,0.f,0.f});
 

--- a/src/xSTIR/cSTIR/stir_x.cpp
+++ b/src/xSTIR/cSTIR/stir_x.cpp
@@ -356,9 +356,9 @@ ListmodeToSinograms::estimate_randoms()
 }
 
 PETAcquisitionSensitivityModel::
-PETAcquisitionSensitivityModel(PETAcquisitionData& ad)
+PETAcquisitionSensitivityModel(STIRAcquisitionData& ad)
 {
-        std::shared_ptr<PETAcquisitionData>
+        std::shared_ptr<STIRAcquisitionData>
 		sptr_ad(ad.new_acquisition_data());
 	sptr_ad->inv(MIN_BIN_EFFICIENCY, ad);
         stir::shared_ptr<BinNormalisation> 
@@ -407,14 +407,14 @@ PETAcquisitionSensitivityModel::set_up(const shared_ptr<const ExamInfo>& sptr_ei
 }
 
 void
-PETAcquisitionSensitivityModel::unnormalise(PETAcquisitionData& ad) const
+PETAcquisitionSensitivityModel::unnormalise(STIRAcquisitionData& ad) const
 {
 	BinNormalisation* norm = norm_.get();
 	norm->undo(*ad.data(), 0, 1);
 }
 
 void
-PETAcquisitionSensitivityModel::normalise(PETAcquisitionData& ad) const
+PETAcquisitionSensitivityModel::normalise(STIRAcquisitionData& ad) const
 {
 	BinNormalisation* norm = norm_.get();
 #if STIR_VERSION < 050000
@@ -437,7 +437,7 @@ PETAttenuationModel::PETAttenuationModel
 }
 
 void
-PETAttenuationModel::unnormalise(PETAcquisitionData& ad) const
+PETAttenuationModel::unnormalise(STIRAcquisitionData& ad) const
 {
 	//std::cout << "in PETAttenuationModel::unnormalise\n";
 	BinNormalisation* norm = norm_.get();
@@ -447,7 +447,7 @@ PETAttenuationModel::unnormalise(PETAcquisitionData& ad) const
 }
 
 void
-PETAttenuationModel::normalise(PETAcquisitionData& ad) const
+PETAttenuationModel::normalise(STIRAcquisitionData& ad) const
 {
 	BinNormalisation* norm = norm_.get();
         stir::shared_ptr<DataSymmetriesForViewSegmentNumbers>
@@ -461,9 +461,9 @@ PETAttenuationModel::normalise(PETAcquisitionData& ad) const
 
 //void
 //PETAcquisitionModel::set_bin_efficiency
-//(shared_ptr<PETAcquisitionData> sptr_data)
+//(shared_ptr<STIRAcquisitionData> sptr_data)
 //{
-//	std::shared_ptr<PETAcquisitionData>
+//	std::shared_ptr<STIRAcquisitionData>
 //		sptr_ad(sptr_data->new_acquisition_data());
 //	sptr_ad->inv(MIN_BIN_EFFICIENCY, *sptr_data);
 //	sptr_normalisation_.reset
@@ -473,7 +473,7 @@ PETAttenuationModel::normalise(PETAcquisitionData& ad) const
 
 void
 PETAcquisitionModel::set_up(
-                            std::shared_ptr<PETAcquisitionData> sptr_acq,
+                            std::shared_ptr<STIRAcquisitionData> sptr_acq,
                             std::shared_ptr<STIRImageData> sptr_image)
 {
 	Succeeded s = Succeeded::no;
@@ -504,7 +504,7 @@ PETAcquisitionModel::set_image_data_processor(stir::shared_ptr<ImageDataProcesso
 }
 
 void 
-PETAcquisitionModel::forward(PETAcquisitionData& ad, const STIRImageData& image,
+PETAcquisitionModel::forward(STIRAcquisitionData& ad, const STIRImageData& image,
 	int subset_num, int num_subsets, bool zero, bool do_linear_only) const
 {
         stir::shared_ptr<ProjData> sptr_fd = ad.data();
@@ -541,13 +541,13 @@ PETAcquisitionModel::forward(PETAcquisitionData& ad, const STIRImageData& image,
 		if (stir::Verbosity::get() > 1) std::cout << "no background term added\n";
 }
 
-std::shared_ptr<PETAcquisitionData>
+std::shared_ptr<STIRAcquisitionData>
 PETAcquisitionModel::forward(const STIRImageData& image, 
 	int subset_num, int num_subsets, bool do_linear_only) const
 {
 	if (!sptr_acq_template_.get())
 		THROW("Fatal error in PETAcquisitionModel::forward: acquisition template not set");
-        std::shared_ptr<PETAcquisitionData> sptr_ad =
+        std::shared_ptr<STIRAcquisitionData> sptr_ad =
           sptr_acq_template_->new_acquisition_data();
         stir::shared_ptr<ProjData> sptr_fd = sptr_ad->data();
 	forward(*sptr_ad, image, subset_num, num_subsets, num_subsets > 1, do_linear_only);
@@ -555,7 +555,7 @@ PETAcquisitionModel::forward(const STIRImageData& image,
 }
 
 std::shared_ptr<STIRImageData> 
-PETAcquisitionModel::backward(PETAcquisitionData& ad,
+PETAcquisitionModel::backward(STIRAcquisitionData& ad,
 	int subset_num, int num_subsets) const
 {
 	if (!sptr_image_template_.get())
@@ -567,7 +567,7 @@ PETAcquisitionModel::backward(PETAcquisitionData& ad,
 }
 
 void
-PETAcquisitionModel::backward(STIRImageData& id, PETAcquisitionData& ad,
+PETAcquisitionModel::backward(STIRImageData& id, STIRAcquisitionData& ad,
 	int subset_num, int num_subsets) const
 {
         stir::shared_ptr<Image3DF> sptr_im = id.data_sptr();
@@ -575,7 +575,7 @@ PETAcquisitionModel::backward(STIRImageData& id, PETAcquisitionData& ad,
 	PETAcquisitionSensitivityModel* sm = sptr_asm_.get();
 	if (sm && sm->data() && !sm->data()->is_trivial()) {
 		if (stir::Verbosity::get() > 1) std::cout << "applying unnormalisation...";
-                std::shared_ptr<PETAcquisitionData> sptr_ad(ad.new_acquisition_data());
+                std::shared_ptr<STIRAcquisitionData> sptr_ad(ad.new_acquisition_data());
 		sptr_ad->fill(ad);
 		sptr_asm_->unnormalise(*sptr_ad);
 		//sptr_normalisation_->undo(*sptr_ad->data(), 0, 1);

--- a/src/xSTIR/cSTIR/tests/test1.cpp
+++ b/src/xSTIR/cSTIR/tests/test1.cpp
@@ -84,7 +84,7 @@ int test1()
 		//filename = SIRF_path + "/data/examples/PET/Utahscat600k_ca_seg4.hs";
 		filename = SIRF_path + "/data/examples/PET/my_forward_projection.hs";
 		fix_path_separator(filename);
-		CREATE_OBJECT(PETAcquisitionData, PETAcquisitionDataInFile,
+		CREATE_OBJECT(STIRAcquisitionData, STIRAcquisitionDataInFile,
 			acq_data, sptr_ad, filename.c_str());
 		sinos = acq_data.get_num_sinograms();
 		views = acq_data.get_num_views();
@@ -98,7 +98,7 @@ int test1()
 
 		// all acquisition-like data except acq_data will be stored in memory
 		// (default storage is temporary files)
-		PETAcquisitionDataInMemory::set_as_template();
+		STIRAcquisitionDataInMemory::set_as_template();
 
 		// create compatible image
 		CREATE_OBJ(STIRImageData, image_data, sptr_id, acq_data);
@@ -134,16 +134,16 @@ int test1()
 		image_data.set_modality(mod);
 
 		// create additive term
-		shared_ptr<PETAcquisitionData> sptr_a = acq_data.new_acquisition_data();
-		PETAcquisitionData& at = *sptr_a;
+		shared_ptr<STIRAcquisitionData> sptr_a = acq_data.new_acquisition_data();
+		STIRAcquisitionData& at = *sptr_a;
 		at.fill(0.05f);
 		// create background term
-		shared_ptr<PETAcquisitionData> sptr_b = acq_data.new_acquisition_data();
-		PETAcquisitionData& bt = *sptr_b;
+		shared_ptr<STIRAcquisitionData> sptr_b = acq_data.new_acquisition_data();
+		STIRAcquisitionData& bt = *sptr_b;
 		bt.fill(0.1f);
 		// create bin efficiencies term
-		shared_ptr<PETAcquisitionData> sptr_e = acq_data.new_acquisition_data();
-		PETAcquisitionData& be = *sptr_e;
+		shared_ptr<STIRAcquisitionData> sptr_e = acq_data.new_acquisition_data();
+		STIRAcquisitionData& be = *sptr_e;
 		be.fill(2.0f);
 
 		// create acquisition model that uses ray tracing matrix
@@ -216,8 +216,8 @@ int test1()
 
 		// forward-project the image to simulate the acquisition process
 		std::cout << "projecting...\n";
-		shared_ptr<PETAcquisitionData> sptr_sd = am.forward(image_data);
-		PETAcquisitionData& sim_data = *sptr_sd;
+		shared_ptr<STIRAcquisitionData> sptr_sd = am.forward(image_data);
+		STIRAcquisitionData& sim_data = *sptr_sd;
 		sinos = sim_data.get_num_sinograms();
 		views = sim_data.get_num_views();
 		tangs = sim_data.get_num_tangential_poss();
@@ -228,8 +228,8 @@ int test1()
 		std::cout << "simulated data norm: " << sim_norm << '\n';
 
 		// compare the simulated acquisition data with raw acquisition data
-		shared_ptr<PETAcquisitionData> sptr_diff(acq_data.new_acquisition_data());
-		PETAcquisitionData& acq_diff = *sptr_diff;
+		shared_ptr<STIRAcquisitionData> sptr_diff(acq_data.new_acquisition_data());
+		STIRAcquisitionData& acq_diff = *sptr_diff;
 		float alpha = 1.0 / sim_norm;
 		float beta = -alpha;
 		acq_diff.axpby
@@ -273,7 +273,7 @@ int test1()
 		fail = fail || !ok;
 
 		// restore the default storage scheme
-		PETAcquisitionDataInFile::set_as_template();
+		STIRAcquisitionDataInFile::set_as_template();
 
 		h.set_information_channel(0);
 

--- a/src/xSTIR/cSTIR/tests/test4.cpp
+++ b/src/xSTIR/cSTIR/tests/test4.cpp
@@ -58,7 +58,7 @@ int test4()
 
 		std::string f_listmode = path + "list.l.hdr";
 		std::string f_template = path + "mMR_template_span11_small.hs";
-		PETAcquisitionDataInFile acq_data_template(f_template.c_str());
+		STIRAcquisitionDataInFile acq_data_template(f_template.c_str());
 
 		// Listmode to sinograms
 		ListmodeToSinograms converter;
@@ -111,9 +111,9 @@ int test4()
         std::cout << "\nTesting NiftyPET projection...\n";
         // Load mMR sinogram
         const std::string f_mMR_template = f_template = path + "mMR_template_span11.hs";
-        PETAcquisitionDataInFile mMR_template(f_mMR_template.c_str());
-        std::shared_ptr<PETAcquisitionDataInMemory> acq_data_mMR_sptr(
-                    new PETAcquisitionDataInMemory(mMR_template));
+        STIRAcquisitionDataInFile mMR_template(f_mMR_template.c_str());
+        std::shared_ptr<STIRAcquisitionDataInMemory> acq_data_mMR_sptr(
+                    new STIRAcquisitionDataInMemory(mMR_template));
         acq_data_mMR_sptr->fill(1.f);
 
         // Create mMR image
@@ -134,7 +134,7 @@ int test4()
         acq_model.set_up(acq_data_mMR_sptr, im_mMR_sptr);
         std::cout << "\nForward projecting with NiftyPET acquisition model...\n";
 
-        std::shared_ptr<PETAcquisitionData> prj_sptr = acq_model.forward(*im_mMR_sptr);
+        std::shared_ptr<STIRAcquisitionData> prj_sptr = acq_model.forward(*im_mMR_sptr);
         std::cout << "\nBack projecting with NiftyPET acquisition model...\n";
         im_mMR_sptr = acq_model.backward(*prj_sptr);
         std::cout << "\nNiftyPET test succeeded.\n";


### PR DESCRIPTION
## Changes in this pull request

STIR now handles SPECT in addition to PET, so we should use prefix STIR for STIR data containers.

This was already in place for images - this pull request does the same for acquisition data.

For the sake of backward compatibility, the old nomenclature is preserved for the time being via `typedef`.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1126.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
