### PR TITLE
Fix mrdata dimensions

### DIFF
--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -193,11 +193,17 @@ MRAcquisitionData::get_acquisitions_dimensions(size_t ptr_dim) const
     int* dim = (int*)ptr_dim;
     ISMRMRD::Acquisition acq;
     get_acquisition(0, acq);
+    int counter_first_valid_acq = 1;
+    while(TO_BE_IGNORED(acq) && counter_first_valid_acq < this->number())
+    {
+        get_acquisition(counter_first_valid_acq, acq);
+        counter_first_valid_acq++;
+    }
 
     int ns = acq.number_of_samples();
     int nc = acq.active_channels();
 
-    for(int i=1; i<na; ++i)
+    for(int i=counter_first_valid_acq; i<na; ++i)
     {
         get_acquisition(i, acq);
         ASSERT(acq.number_of_samples() == ns, "One of your acquisitions has a different number of samples. Please make sure the dimensions are consistent.");

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -962,8 +962,8 @@ class AcquisitionData(DataContainer):
         if self.number() < 1:
             return numpy.zeros((MAX_ACQ_DIMENSIONS,), dtype=cpp_int_dtype())
         dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype=cpp_int_dtype())
-        hv = pygadgetron.cGT_getAcquisitionDataDimensions\
-             (self.handle, dim.ctypes.data)
+        hv = try_calling(pygadgetron.cGT_getAcquisitionDataDimensions\
+             (self.handle, dim.ctypes.data))
         pyiutil.deleteDataHandle(hv)
         dim[2] = numpy.prod(dim[2:])
         return tuple(dim[2::-1])


### PR DESCRIPTION
## Changes in this pull request
Checks dimensions of k-space only for acquisitions that are not ignored.
Catches runtime errors that are caused by C++ code in sirf.Gadgetron.AcquisitionData.dimension()` function

## Testing performed
Used code on file which previously caused wrong dimensions. Yielded correct dimensions afterwards.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes #1160 


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
