### PR TITLE
[GHA] fix gcc8 test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           compiler: gcc
           compiler_version: 8
           DEVEL_BUILD: "OFF"


### PR DESCRIPTION
force gcc-8 test to ubuntu 20.04 as it is no longer in ubuntu 22.04
