### PR TITLE
Sorted out various issues with PET demos

### DIFF
--- a/examples/Python/PET/STIR_acquisition_model_using_raytracing.py
+++ b/examples/Python/PET/STIR_acquisition_model_using_raytracing.py
@@ -1,7 +1,10 @@
 '''Demo for setting advanced parameters in sirf.STIR.AcquisitionModelUsingRayTracingMatrix
 
 Usage:
-  STIR_acquisition_model_using_raytracing.py
+  STIR_acquisition_model_using_raytracing [options]
+
+Options:
+  --non-interactive           do not show plots
 
 This just sets some parameters and prints settings. Check other demos on how to use it.
 '''

--- a/examples/Python/PET/acquisition_sensitivity_from_attenuation.py
+++ b/examples/Python/PET/acquisition_sensitivity_from_attenuation.py
@@ -10,7 +10,7 @@ Options:
                                subfolder of SIRF root folder
   -e <engn>, --engine=<engn>   reconstruction engine [default: STIR]
   -s <stsc>, --storage=<stsc>  acquisition data storage scheme [default: file]
-  -o <file>, --output=<file>   output attenuation factors sinogram
+  -o <file>, --output=<file>   output attenuation factors sinogram [default: acf.hs]
   --non-interactive            do not show plots
 '''
 

--- a/examples/Python/PET/get_multiplicative_sinogram.py
+++ b/examples/Python/PET/get_multiplicative_sinogram.py
@@ -12,6 +12,7 @@ Options:
   -O <outp>, --outp=<outp>      output file [default: multiplicative]
   -T <file>, --trans=<file>     transform for attn image
   -t <str>, --trans_type=<str>  transform type (tm, disp, def) [default: tm]
+  --non-interactive           do not show plots
 """
 
 # SyneRBI Synergistic Image Reconstruction Framework (SIRF)

--- a/examples/Python/PET/plot_measured_data.py
+++ b/examples/Python/PET/plot_measured_data.py
@@ -8,6 +8,7 @@ Options:
   -f <file>, --file=<file>    raw data file [default: sinograms_f1g1d0b0.hs]
   -r <file>, --randoms=<file> filename with randoms [default: None]
   -s <file>, --scatter=<file> scatter data file [default: None]
+  --non-interactive           do not show plots
 '''
 
 ## CCP SyneRBI Synergistic Image Reconstruction Framework (SIRF)
@@ -31,6 +32,8 @@ __version__ = '1.0.0'
 from docopt import docopt
 
 args = docopt(__doc__, version=__version__)
+if args['--non-interactive']:
+    exit()
 
 prompts = args["--file"]
 scatter = args["--scatter"]

--- a/examples/Python/PET/reconstruct_from_listmode.py
+++ b/examples/Python/PET/reconstruct_from_listmode.py
@@ -12,7 +12,7 @@ Options:
   -a <attn>, --attn=<attn>     attenuation image file file [default: mu_map.hv]
   -n <norm>, --norm=<norm>     ECAT8 bin normalization file [default: norm.n.hdr]
   -I <int>, --interval=<int>   scanning time interval to convert as string '(a,b)'
-                               (no space after comma) [default: (0,50)]
+                               (no space after comma) [default: (0,100)]
   -d <nxny>, --nxny=<nxny>     image x and y dimensions as string '(nx,ny)'
                                (no space after comma) [default: (127,127)]
   -S <subs>, --subs=<subs>     number of subsets [default: 7]

--- a/examples/Python/PET/run_all.py
+++ b/examples/Python/PET/run_all.py
@@ -22,10 +22,8 @@ import glob
 import os
 import sys
 
-for i in glob.glob('*.py'):
+for i in sorted(glob.glob('*.py')):
     narg = len(sys.argv)
-    if narg > 1 and i.find('listmode') >= 0:
-        continue
     if os.path.abspath(__file__) == os.path.abspath(i):
         continue
     print('\n=== %s\n' % i)

--- a/examples/Python/PET/scatter_estimation.py
+++ b/examples/Python/PET/scatter_estimation.py
@@ -9,8 +9,8 @@ Usage:
   scatter_estimation [--help | options]
 
 Options: (defaults are set to work for mMR data processed in the current directory)
-  -f <file>, --file=<file>    raw data file [default: sinospan11_f1g1d0b0.hs]
-  -r <file>, --randoms=<file>  filename with randoms [default: MLrandomsspan11_f1.hs]
+  -f <file>, --file=<file>    raw data file [default: sinograms_f1g1d0b0.hs]
+  -r <file>, --randoms=<file>  filename with randoms [default: randoms.hs]
   -p <path>, --path=<path>    path to normalization and attenuation files,
                               defaults to data/examples/PET/mMR
   -n <norm>, --norm=<norm>    normalization file [default: norm.n.hdr]
@@ -21,7 +21,7 @@ Options: (defaults are set to work for mMR data processed in the current directo
   -o <file>, --output=<file>  output prefix for scatter estimates [default: scatter_estimate]
                               ("_#.hs" will be appended, with # the iteration number).
                               Set this to an empty string to prevent output on disk.
-
+  --non-interactive           do not show plots
 '''
 
 ## CCP SyneRBI Synergistic Image Reconstruction Framework (SIRF)
@@ -65,6 +65,7 @@ if data_path is None:
 norm_file = PET.existing_filepath(data_path, args['--norm'])
 mu_map_file = PET.existing_filepath(data_path, args['--attenuation_image'])
 output_prefix = args['--output']
+interactive = not args['--non-interactive']
 
 
 def main():
@@ -100,6 +101,9 @@ def main():
     se.set_up()
     se.process()
     scatter_estimate = se.get_output()
+
+    if not interactive:
+        return
 
     ## show estimated scatter data
     scatter_estimate_as_array = scatter_estimate.as_array()

--- a/examples/Python/PET/scatter_simulation.py
+++ b/examples/Python/PET/scatter_simulation.py
@@ -11,6 +11,7 @@ Options:
   -p <path>, --path=<path>    path to data files, defaults to data/examples/PET
                               subfolder of SIRF root folder
   -o <file>, --output=<file>  output file for simulated data [default: scatter_output.hs]
+  --non-interactive           do not show plots
 
 WARNING: Currently this computes scatter at the same sampling as the template. If you use
 real projection data as template, this will be very slow (and might run out of memory).
@@ -55,6 +56,7 @@ if data_path is None:
     print(data_path)
 acq_template_filename = PET.existing_filepath(data_path, data_file)
 output_file = args['--output']
+interactive = not args['--non-interactive']
 
 
 def main():
@@ -85,9 +87,10 @@ def main():
     # z-pixel coordinate of the xy-crossection to show
     z = int(image_size[0]*0.5)
 
-    # show the phantom image
-    atten_image_array = atten_image.as_array()
-    show_2D_array('Attenuation image', atten_image_array[z,:,:])
+    if interactive:
+        # show the phantom image
+        atten_image_array = atten_image.as_array()
+        show_2D_array('Attenuation image', atten_image_array[z,:,:])
 
     # Create the activity image
     act_image = atten_image.clone()
@@ -107,9 +110,10 @@ def main():
     # z-pixel coordinate of the xy-crossection to show
     z = int(image_size[0] * 0.5)
 
-    # show the phantom image
-    act_image_array = act_image.as_array()
-    show_2D_array('Activity image', act_image_array[z, :, :])
+    if interactive:
+        # show the phantom image
+        act_image_array = act_image.as_array()
+        show_2D_array('Activity image', act_image_array[z, :, :])
 
     # Create the Single Scatter Simulation model
     sss = PET.SingleScatterSimulator()
@@ -122,9 +126,10 @@ def main():
     # Simulate!
     sss_data = sss.forward(act_image)
 
-    # show simulated scatter data
-    simulated_scatter_as_array = sss_data.as_array()
-    show_2D_array('scatter simulation', simulated_scatter_as_array[0,0,:,:])
+    if interactive:
+        # show simulated scatter data
+        simulated_scatter_as_array = sss_data.as_array()
+        show_2D_array('scatter simulation', simulated_scatter_as_array[0,0,:,:])
 
     sss_data.write(output_file)
 
@@ -138,6 +143,8 @@ def main():
     #unscattered_data = acq_template.get_uniform_copy()
     unscattered_data = acq_model.forward(act_image)
     simulated_unscatter_as_array = unscattered_data.as_array()
+    if not interactive:
+        return
     show_2D_array('unscattered simulation', simulated_unscatter_as_array[0,0,:,:])
 
     plt.figure()


### PR DESCRIPTION
## Changes in this pull request

* added missing `--non-interactive` option and skipping data displays in non-interactive mode
* added missing default output to `acf.hs` in `acquisition_sensitivity_from_attenuation.py`
* removed skipping listmode scripts by `run_all.py`
* sorted demos in `run_all.py` (pending more general solution to the execution order problem)
* corrected naming mismatch for some demos output files used as input for some other demos

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
