### PR TITLE
Handling "irregular" MR acquisitions

### DIFF
--- a/examples/Python/MR/acquisition_data.py
+++ b/examples/Python/MR/acquisition_data.py
@@ -57,7 +57,7 @@ def main():
     input_file = existing_filepath(data_path, data_file)
 
     # acquisition data will be read from an HDF file input_file
-    acq_data = AcquisitionData(input_file)
+    acq_data = AcquisitionData(input_file, all=True)
 
     # the raw k-space data is a list of different readouts
     # of different data type (e.g. noise correlation data, navigator data,

--- a/examples/Python/MR/acquisition_data.py
+++ b/examples/Python/MR/acquisition_data.py
@@ -57,7 +57,7 @@ def main():
     input_file = existing_filepath(data_path, data_file)
 
     # acquisition data will be read from an HDF file input_file
-    acq_data = AcquisitionData(input_file, all=True)
+    acq_data = AcquisitionData(input_file)
 
     # the raw k-space data is a list of different readouts
     # of different data type (e.g. noise correlation data, navigator data,

--- a/src/xGadgetron/cGadgetron/cgadgetron.cpp
+++ b/src/xGadgetron/cGadgetron/cgadgetron.cpp
@@ -488,14 +488,14 @@ cGT_sortAcquisitionsByTime(void* ptr_acqs)
 
 extern "C"
 void*
-cGT_ISMRMRDAcquisitionsFromFile(const char* file)
+cGT_ISMRMRDAcquisitionsFromFile(const char* file, int all)
 {
 	if (!file_exists(file))
 		return fileNotFound(file, __FILE__, __LINE__);
 	try {
 		shared_ptr<MRAcquisitionData>
 			acquisitions(new AcquisitionsVector);
-		acquisitions->read(file);
+		acquisitions->read(file, all);
 		return newObjectHandle<MRAcquisitionData>(acquisitions);
 	}
 	CATCH;

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -102,7 +102,7 @@ MRAcquisitionData::write(const std::string &filename) const
 }
 
 void
-MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
+MRAcquisitionData::read(const std::string& filename_ismrmrd_with_ext, int all)
 {
 	
     bool const verbose = true;
@@ -158,9 +158,7 @@ MRAcquisitionData::read( const std::string& filename_ismrmrd_with_ext )
 			d.readAcquisition( i_acqu, acq);
 			mtx.unlock();
 
-			if( TO_BE_IGNORED(acq) )
-				continue;
-			else
+			if(all || !TO_BE_IGNORED(acq))
 				this->append_acquisition( acq );
 		}
         this->sort_by_time();

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -190,22 +190,30 @@ MRAcquisitionData::get_acquisitions_dimensions(size_t ptr_dim) const
 
     int* dim = (int*)ptr_dim;
     ISMRMRD::Acquisition acq;
-    get_acquisition(0, acq);
+    int ns;
+    int nc;
+    int num_acq = 0;
 
-    int ns = acq.number_of_samples();
-    int nc = acq.active_channels();
-
-    for(int i=1; i<na; ++i)
+    for (int i = 0; i < na; ++i)
     {
         get_acquisition(i, acq);
-        ASSERT(acq.number_of_samples() == ns, "One of your acquisitions has a different number of samples. Please make sure the dimensions are consistent.");
-        ASSERT(acq.active_channels() == nc, "One of your acquisitions has a different number of active channels. Please make sure the dimensions are consistent.");
+        if (TO_BE_IGNORED(acq))
+            continue;
+        if (num_acq == 0) {
+            ns = acq.number_of_samples();
+            nc = acq.active_channels();
+        }
+        else {
+            ASSERT(acq.number_of_samples() == ns, "One of your acquisitions has a different number of samples. Please make sure the dimensions are consistent.");
+            ASSERT(acq.active_channels() == nc, "One of your acquisitions has a different number of active channels. Please make sure the dimensions are consistent.");
+        }
+        num_acq++;
     }
 
     int const num_dims = 3;
     dim[0] = ns;
     dim[1] = nc;
-    dim[2] = na;
+    dim[2] = num_acq;
 
     return num_dims;
 }

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/cgadgetron.h
@@ -64,7 +64,7 @@ extern "C" {
 	void* cGT_AcquisitionModelBackward(void* ptr_am, const void* ptr_acqs);
 
 	// acquisition data methods
-	void* cGT_ISMRMRDAcquisitionsFromFile(const char* file);
+	void* cGT_ISMRMRDAcquisitionsFromFile(const char* file, int all);
 	void* cGT_ISMRMRDAcquisitionsFile(const char* file);
 	void* cGT_processAcquisitions(void* ptr_proc, void* ptr_input);
 	void* cGT_acquisitionFromContainer(void* ptr_acqs, unsigned int acq_num);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -527,7 +527,7 @@ namespace sirf {
 			* To avoid reading noise samples and other calibration data, the TO_BE_IGNORED macro is employed
 			* to exclude potentially incompatible input. 
     	*/
-		void read( const std::string& filename_ismrmrd_with_ext );
+		void read(const std::string& filename_ismrmrd_with_ext, int all = 0);
 
 	protected:
 		bool sorted_ = false;
@@ -558,9 +558,9 @@ namespace sirf {
 	*/
 	class AcquisitionsVector : public MRAcquisitionData {
 	public:
-        AcquisitionsVector(const std::string& filename_with_ext)
+        AcquisitionsVector(const std::string& filename_with_ext, int all = 0)
         {
-            this->read(filename_with_ext);
+            this->read(filename_with_ext, all);
         }
 
         AcquisitionsVector(const AcquisitionsInfo& info = AcquisitionsInfo())

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -800,12 +800,12 @@ class AcquisitionData(DataContainer):
     Class for an MR acquisitions container.
     Each item is a 2D complex array of acquisition samples for each coil.
     '''
-    def __init__(self, file = None):
+    def __init__(self, file=None, all=False):
         self.handle = None
         self.sorted = False
         self.info = None
         if file is not None:
-            self.handle = pygadgetron.cGT_ISMRMRDAcquisitionsFromFile(file)
+            self.handle = pygadgetron.cGT_ISMRMRDAcquisitionsFromFile(file, 1*all)
             check_status(self.handle)
 
     def __del__(self):

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -962,9 +962,8 @@ class AcquisitionData(DataContainer):
         if self.number() < 1:
             return numpy.zeros((MAX_ACQ_DIMENSIONS,), dtype=cpp_int_dtype())
         dim = numpy.ones((MAX_ACQ_DIMENSIONS,), dtype=cpp_int_dtype())
-        hv = pygadgetron.cGT_getAcquisitionDataDimensions\
-             (self.handle, dim.ctypes.data)
-        pyiutil.deleteDataHandle(hv)
+        try_calling(pygadgetron.cGT_getAcquisitionDataDimensions\
+             (self.handle, dim.ctypes.data))
         dim[2] = numpy.prod(dim[2:])
         return tuple(dim[2::-1])
 


### PR DESCRIPTION
## Changes in this pull request

In SIRF, some MR acquisitions are "irregular" and need to be excluded from certain operations on acquisition data objects, e.g. algebraic operations. A prime example is noise calibration data. This fact was not taken into account in some `MRAcquisitionData` methods dealing with "regular" data dimensions, leading to errors. As a quick fix, all "irregular" acquisitions are currently thrown away altogether when reading acquisitions data from a file. This PR aims to implement a more flexible approach whereby "irregular" acquisitions are only ignored where they have to be ignored.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
