### PR TITLE
removes ubuntu 20.04 from GHA

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,12 +25,13 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-20.04
-          compiler: gcc
-          compiler_version: 8
-          DEVEL_BUILD: "OFF"
-          EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
-          CMAKE_BUILD_TYPE: "Release"
+# remove Ubuntu 20.04 until #1179
+#         - os: ubuntu-20.04
+#           compiler: gcc
+#           compiler_version: 8
+#           DEVEL_BUILD: "OFF"
+#           EXTRA_BUILD_FLAGS: "-DUSE_ITK=ON"
+#           CMAKE_BUILD_TYPE: "Release"
         - os: ubuntu-latest
           compiler: gcc
           compiler_version: 9

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## v3.5.0
-
+* GitHub Action: remove temporarily the Ubuntu 20.04 build, #1178
 * MR
   - Re-designed handling of "irregular" ISMRMRD acquisitions, making it user-controlled and more flexible. See https://github.com/SyneRBI/SIRF/pull/1174 for more information
 


### PR DESCRIPTION
## Changes in this pull request

Temporarily removes the Ubuntu20.04 from the GHA.
## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

closes #1178

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [x] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
