### PR TITLE
Set rad traj

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * GitHub Action: remove temporarily the Ubuntu 20.04 build, #1178
 * MR
   - Re-designed handling of "irregular" ISMRMRD acquisitions, making it user-controlled and more flexible. See https://github.com/SyneRBI/SIRF/pull/1174 for more information
+  - Allow user to set radial, goldenangle, spiral and rpe trajectories
 
 ## v3.4.0
 

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1699,7 +1699,7 @@ def set_data_trajectory(ad, traj, traj_type_str):
         # Check trajectory type
         supported_traj = ['radial', 'goldenangle', 'spiral', 'rpe']
         if traj_type_str not in supported_traj:
-            raise Error("Trajectory type {} cannot be set. Only {} can be set.".format(traj_type_str, supported_traj))
+            raise error("Trajectory type {} cannot be set. Only {} can be set.".format(traj_type_str, supported_traj))
         
         # Check dimensions of trajectory
         dims = ad.dimensions()

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1641,8 +1641,18 @@ def set_grpe_trajectory(ad, traj=None):
     if traj is None:
         try_calling(pygadgetron.cGT_setGRPETrajectory(ad.handle))
     else:
-        raise NotImplementedError("RPE trajectory can not be set yet.")
-   
+        traj_type = int(5) # == other
+        pygadgetron.cGT_setTrajectoryType(ad.handle, traj_type)
+
+        traj_dim = int(3)
+        dims = ad.dimensions()
+        num_samples = dims[0]
+        expected_traj_shape = (num_samples, traj_dim)
+
+        if traj.shape != expected_traj_shape:
+            raise AssertionError("Pass the RPE trajectory in the shape {}. You gave a shape of {}".format(expected_traj_shape, traj.shape))
+        
+        ad = set_data_trajectory(ad, traj)
     return ad
     
 def set_radial2D_trajectory(ad, traj=None):

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1663,7 +1663,7 @@ def set_radial2D_trajectory(ad, traj=None):
         expected_traj_shape = (num_readouts, num_samples, traj_dim)
 
         if traj.shape != expected_traj_shape:
-            raise AssertionError("Pass the radial trajectory in the shape {}. You gave a shape of {}".format(expected_traj.shape, traj.shape))
+            raise AssertionError("Pass the radial trajectory in the shape {}. You gave a shape of {}".format(expected_traj_shape, traj.shape))
         
         ad = set_data_trajectory(ad, traj)
     return ad
@@ -1696,7 +1696,7 @@ def set_spiral2D_trajectory(ad, traj):
     expected_traj_shape = (num_readouts, num_samples, traj_dim)
 
     if traj.shape != expected_traj_shape:
-        raise AssertionError("Pass the spiral trajectory in the shape {}. You gave a shape of {}".format(expected_traj.shape, traj.shape))
+        raise AssertionError("Pass the spiral trajectory in the shape {}. You gave a shape of {}".format(expected_traj_shape, traj.shape))
     
     return(set_data_trajectory(ad, traj))
     

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1638,7 +1638,7 @@ def set_grpe_trajectory(ad, traj=None):
     '''    
     assert_validity(ad, AcquisitionData)
 
-    if traj == None:
+    if traj is None:
         try_calling(pygadgetron.cGT_setGRPETrajectory(ad.handle))
     else:
         raise NotImplementedError("RPE trajectory can not be set yet.")
@@ -1653,7 +1653,7 @@ def set_radial2D_trajectory(ad, traj=None):
     '''
     assert_validity(ad, AcquisitionData)
 
-    if traj == None:
+    if traj is None:
         try_calling(pygadgetron.cGT_setRadial2DTrajectory(ad.handle))
     else:
         traj_dim = int(2)
@@ -1676,7 +1676,7 @@ def set_goldenangle2D_trajectory(ad, traj=None):
     '''
     assert_validity(ad, AcquisitionData)
 
-    if traj == None:
+    if traj is None:
         try_calling(pygadgetron.cGT_setGoldenAngle2DTrajectory(ad.handle))
     else:
         ad = set_radial2D_trajectory(ad, traj)

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1652,6 +1652,9 @@ def set_grpe_trajectory(ad, traj=None):
         if traj.shape != expected_traj_shape:
             raise AssertionError("Pass the RPE trajectory in the shape {}. You gave a shape of {}".format(expected_traj_shape, traj.shape))
         
+        # Same phase encoding trajectory for each readout
+        traj = numpy.tile(traj[:,numpy.newaxis,:], (1,dims[2],1))
+
         ad = set_data_trajectory(ad, traj)
     return ad
     

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1633,7 +1633,7 @@ def preprocess_acquisition_data(input_data):
 def set_grpe_trajectory(ad, traj=None):
     '''
     Function that fills the trajectory of AcquisitionData with golden angle radial
-    phase encoding trajectory (traj=None) or fills in a precaculated RPE trajectory.
+    phase encoding trajectory (traj=None) or fills in a precalculated RPE trajectory.
     ad: AcquisitionData
     '''    
     assert_validity(ad, AcquisitionData)
@@ -1661,7 +1661,7 @@ def set_grpe_trajectory(ad, traj=None):
 def set_radial2D_trajectory(ad, traj=None):
     '''
     Function that fills the trajectory of AcquisitionData with linear increment 2D radial
-    readout trajectory (traj=None) or fills in a precaculated radial trajectory.
+    readout trajectory (traj=None) or fills in a precalculated radial trajectory.
     ad: AcquisitionData
     '''
     assert_validity(ad, AcquisitionData)
@@ -1684,7 +1684,7 @@ def set_radial2D_trajectory(ad, traj=None):
 def set_goldenangle2D_trajectory(ad, traj=None):
     '''
     Function that fills the trajectory of AcquisitionData with golden angle increment 2D radial
-    readout trajectory (traj=None) or fills in a precaculated radial trajectory.
+    readout trajectory (traj=None) or fills in a precalculated radial trajectory.
     ad: AcquisitionData
     '''
     assert_validity(ad, AcquisitionData)

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -1,4 +1,4 @@
-''' 
+'''
 Object-Oriented wrap for the cGadgetron-to-Python interface pygadgetron.py
 '''
 
@@ -234,7 +234,7 @@ class Image(object):
 class ImageData(SIRF.ImageData):
     '''
     Class for an MR images container.
-    Each item in the container is a 3D complex or float array of the image 
+    Each item in the container is a 3D complex or float array of the image
     values on an xyz-slice (z-dimension is normally 1).
     '''
     def __init__(self, file = None):
@@ -281,7 +281,7 @@ class ImageData(SIRF.ImageData):
     def data_type(self, im_num):
         '''
         Returns the data type for a specified image (see 8 data types above).
-        im_num: image (slice) 
+        im_num: image (slice)
         '''
         assert self.handle is not None
         handle = pygadgetron.cGT_imageDataType(self.handle, im_num)
@@ -303,7 +303,7 @@ class ImageData(SIRF.ImageData):
         '''
         Returns processed self with an image processor specified by
         a list of gadgets.
-        list: Python list of gadget description strings, each gadget 
+        list: Python list of gadget description strings, each gadget
               description being a string of the form
                 '[label:]gadget_name[(property1=value1[,...])]'
               (square brackets embrace optional items, ... stands for etc.)
@@ -330,7 +330,7 @@ class ImageData(SIRF.ImageData):
 
     def get_ISMRMRD_info(self, par):
         '''
-        Returns the array of values of the specified image information 
+        Returns the array of values of the specified image information
         parameter. Parameters names are the same as the names of sirf.Gadgetron.Image class
         public methods (except is_real and info).
 
@@ -509,7 +509,7 @@ class ImageData(SIRF.ImageData):
             shape = out.as_array().shape
             seed = kwargs.get('seed', None)
             if seed is not None:
-                numpy.random.seed(seed) 
+                numpy.random.seed(seed)
             if value == 'random':
                 out.fill(numpy.random.random_sample(shape))
             elif value == 'random_int':
@@ -561,7 +561,7 @@ SIRF.ImageData.register(CoilImagesData)
 class CoilSensitivityData(ImageData):
     '''
     Class for a coil sensitivity maps (csm) container.
-    Each item in the container is a 4D complex array of csm values on an 
+    Each item in the container is a 4D complex array of csm values on an
     xyz-slice (z-dimension is normally 1).
     '''
     def __init__(self):
@@ -579,10 +579,10 @@ class CoilSensitivityData(ImageData):
         check_status(self.handle)
     def calculate(self, data, method=None):
         '''
-        Calculates coil sensitivity maps from coil images or sorted 
+        Calculates coil sensitivity maps from coil images or sorted
         acquisitions.
         data  : either AcquisitionData or CoilImages
-        method: either SRSS (Square Root of the Sum of Squares, default) or 
+        method: either SRSS (Square Root of the Sum of Squares, default) or
                 Inati
         '''
         if isinstance(data, AcquisitionData):
@@ -695,7 +695,7 @@ class Acquisition(object):
         return parms.int_par(self.handle, 'acquisition', 'version')
     def flags(self):
         '''
-        Returns acquisition flags as an integer (each bit corresponding to a 
+        Returns acquisition flags as an integer (each bit corresponding to a
         flag).
         '''
         assert self.handle is not None
@@ -893,7 +893,7 @@ class AcquisitionData(DataContainer):
         '''
         Returns processed self with an acquisition processor specified by
         a list of gadgets.
-        list: Python list of gadget description strings, each gadget 
+        list: Python list of gadget description strings, each gadget
               description being a string of the form
                 '[label:]gadget_name[(property1=value1[,...])]'
               (square brackets embrace optional items, ... stands for etc.)
@@ -936,7 +936,7 @@ class AcquisitionData(DataContainer):
         into the raw data.
         data: numpy array
         idx: integer in range 0 to 7
-        '''        
+        '''
         if self.handle is None:
             raise AssertionError('self.handle is None')
                     
@@ -969,7 +969,7 @@ class AcquisitionData(DataContainer):
 
     def get_ISMRMRD_info(self, par, which='all'):
         '''
-        Returns the array of values of the specified acquisition information 
+        Returns the array of values of the specified acquisition information
         parameter.
 
         par: parameter name (see sirf.Gadgetron.Acquisition class methods except info)
@@ -1081,7 +1081,7 @@ class AcquisitionData(DataContainer):
             a = self.acquisition(acq)
             nc = a.active_channels()
             ns = a.number_of_samples()
-            z = numpy.ndarray((nc, ns), dtype = numpy.complex64)            
+            z = numpy.ndarray((nc, ns), dtype = numpy.complex64)
         try_calling(pygadgetron.cGT_acquisitionDataAsArray\
             (self.handle, z.ctypes.data, acq))
         return z
@@ -1137,7 +1137,7 @@ class AcquisitionData(DataContainer):
             shape = out.as_array().shape
             seed = kwargs.get('seed', None)
             if seed is not None:
-                numpy.random.seed(seed) 
+                numpy.random.seed(seed)
             if value == 'random':
                 out.fill(numpy.random.random_sample(shape))
             elif value == 'random_int':
@@ -1323,7 +1323,7 @@ class Gadget(object):
     def set_properties(self, prop):
         '''
         Assigns specified values to specified gadget properties.
-        prop: a string with comma-separated list of property value assignments 
+        prop: a string with comma-separated list of property value assignments
               prop_name=prop_value
         '''
         try_calling(pygadgetron.cGT_setGadgetProperties(self.handle, prop))
@@ -1411,7 +1411,7 @@ class GadgetChain(object):
 
 class Reconstructor(GadgetChain):
     '''
-    Class for a chain of gadgets that has AcquisitionData on input and 
+    Class for a chain of gadgets that has AcquisitionData on input and
     ImageData on output.
     '''
     def __init__(self, list=None):
@@ -1452,7 +1452,7 @@ class Reconstructor(GadgetChain):
              (self.handle, self.input_data.handle, self.dcm_prefix))
     def get_output(self, subset = None):
         '''
-        Returns specified subset of the output ImageData. If no subset is 
+        Returns specified subset of the output ImageData. If no subset is
         specified, returns all output.
         subset: the name of the subset (e.g. images, gfactors,...)
         '''
@@ -1485,7 +1485,7 @@ class ImageDataProcessor(GadgetChain):
     def __init__(self, list = None):
         '''
         Creates an image processor specified by a list of gadgets.
-        list: Python list of gadget description strings, each gadget 
+        list: Python list of gadget description strings, each gadget
               description being a string of the form
                 '[label:]gadget_name[(property1=value1[,...])]'
               (square brackets embrace optional items, ... stands for etc.)
@@ -1542,7 +1542,7 @@ class AcquisitionDataProcessor(GadgetChain):
     def __init__(self, list = None):
         '''
         Creates an acquisition processor specified by a list of gadgets.
-        list: Python list of gadget description strings, each gadget 
+        list: Python list of gadget description strings, each gadget
               description being a string of the form
                 '[label:]gadget_name[(property1=value1[,...])]'
               (square brackets embrace optional items, ... stands for etc.)
@@ -1635,27 +1635,13 @@ def set_grpe_trajectory(ad, traj=None):
     Function that fills the trajectory of AcquisitionData with golden angle radial
     phase encoding trajectory (traj=None) or fills in a precalculated RPE trajectory.
     ad: AcquisitionData
-    '''    
+    '''
     assert_validity(ad, AcquisitionData)
 
     if traj is None:
         try_calling(pygadgetron.cGT_setGRPETrajectory(ad.handle))
     else:
-        traj_type = int(5) # == other
-        pygadgetron.cGT_setTrajectoryType(ad.handle, traj_type)
-
-        traj_dim = int(3)
-        dims = ad.dimensions()
-        num_samples = dims[0]
-        expected_traj_shape = (num_samples, traj_dim)
-
-        if traj.shape != expected_traj_shape:
-            raise AssertionError("Pass the RPE trajectory in the shape {}. You gave a shape of {}".format(expected_traj_shape, traj.shape))
-        
-        # Same phase encoding trajectory for each readout
-        traj = numpy.tile(traj[:,numpy.newaxis,:], (1,dims[2],1))
-
-        ad = set_data_trajectory(ad, traj)
+        ad = set_data_trajectory(ad, traj, 'rpe')
     return ad
     
 def set_radial2D_trajectory(ad, traj=None):
@@ -1669,16 +1655,7 @@ def set_radial2D_trajectory(ad, traj=None):
     if traj is None:
         try_calling(pygadgetron.cGT_setRadial2DTrajectory(ad.handle))
     else:
-        traj_dim = int(2)
-        dims = ad.dimensions()
-        num_readouts = dims[0]
-        num_samples = dims[2]
-        expected_traj_shape = (num_readouts, num_samples, traj_dim)
-
-        if traj.shape != expected_traj_shape:
-            raise AssertionError("Pass the radial trajectory in the shape {}. You gave a shape of {}".format(expected_traj_shape, traj.shape))
-        
-        ad = set_data_trajectory(ad, traj)
+        ad = set_data_trajectory(ad, traj, 'radial')
     return ad
 
 def set_goldenangle2D_trajectory(ad, traj=None):
@@ -1692,35 +1669,60 @@ def set_goldenangle2D_trajectory(ad, traj=None):
     if traj is None:
         try_calling(pygadgetron.cGT_setGoldenAngle2DTrajectory(ad.handle))
     else:
-        ad = set_radial2D_trajectory(ad, traj)
+        ad = set_data_trajectory(ad, traj, 'goldenangle')
     return ad
 
 def set_spiral2D_trajectory(ad, traj):
     '''
     Function that fills in a precalculated spiral trajectory
     '''
-    traj_type = int(4) # == spiral
-    pygadgetron.cGT_setTrajectoryType(ad.handle, traj_type)
-
-    traj_dim = int(2)
-    dims = ad.dimensions()
-    num_readouts = dims[0]
-    num_samples = dims[2]
-    expected_traj_shape = (num_readouts, num_samples, traj_dim)
-
-    if traj.shape != expected_traj_shape:
-        raise AssertionError("Pass the spiral trajectory in the shape {}. You gave a shape of {}".format(expected_traj_shape, traj.shape))
+    if traj is None:
+        raise NotImplementedError("Spiral trajectories cannot be calculated but need to be provided by you.")
+    else:
+        return(set_data_trajectory(ad, traj, 'spiral'))
     
-    return(set_data_trajectory(ad, traj))
-    
-def set_data_trajectory(ad, traj):
+def set_data_trajectory(ad, traj, traj_type_str):
     '''
     Function that sets the trajectory of AcquisitionData with traj.
     ad: AcquisitionData
-    traj: k-space trajectory
-    ''' 
-    traj_dim = int(traj.shape[-1])
+    traj: k-space trajectory as numpy array
+    traj_type_str: String identifying trajectory type
+                    Possible choices are:
+                            - radial
+                            - goldenangle
+                            - spiral
+                            - rpe
+    '''
+    assert_validity(ad, AcquisitionData)
+    assert isinstance(traj, numpy.ndarray), 'Trajectory should be numpy array. Got {}'.format(type(traj))
     
+    # Check trajectory type
+    if traj_type_str == 'radial':
+        traj_type = int(2)
+    elif traj_type_str == 'goldenangle':
+        traj_type = int(3)
+    elif traj_type_str == 'spiral':
+        traj_type = int(4)
+    elif traj_type_str == 'rpe':
+        traj_type = int(5) # other
+    else:
+        raise ValueError("Trajectory type {} cannot be set. Only radial, spiral, goldenangle and rpe can be set.".format(traj_type_str))
+    
+    # Check dimensions of trajectory
+    dims = ad.dimensions()
+    if traj_type_str == 'radial' or traj_type_str == 'goldenangle' or traj_type_str == 'spiral':
+        traj_dim = int(2)
+        expected_traj_shape = (dims[0], dims[2], traj_dim)
+    elif traj_type_str == 'rpe':
+        traj_dim = int(3)
+        expected_traj_shape = (dims[0], traj_dim)
+    if traj.shape != expected_traj_shape:
+        raise AssertionError("Pass the {} trajectory in the shape {}. You gave a shape of {}".format(traj_type_str, expected_traj_shape, traj.shape))
+
+    if traj_type_str == 'rpe':
+        # Same phase encoding trajectory for each readout
+        traj = numpy.tile(traj[:, numpy.newaxis, :], (1, dims[2], 1))
+        
     traj = numpy.array(traj, numpy.float32)
     convert = not traj.flags['C_CONTIGUOUS']
     if convert:
@@ -1733,7 +1735,7 @@ def get_data_trajectory(ad):
     '''
     Function that gets the trajectory of AcquisitionData depending on the rawdata trajectory.
     ad: AcquisitionData
-    '''    
+    '''
     assert_validity(ad, AcquisitionData)
     
     if ad.check_traj_type('cartesian'):
@@ -1757,7 +1759,7 @@ def compute_kspace_density(ad):
     '''
     Function that computes the kspace density depending the
     ad: AcquisitionData
-    '''  
+    '''
     assert_validity(ad, AcquisitionData)
 
     if ad.check_traj_type('cartesian'):


### PR DESCRIPTION
## Changes in this pull request
Set functions added such that trajectory not just for spiral but also radial and RPE can be added from Python.

## Testing performed
All setters were tested with real data.

## Related issues


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [x] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
