### PR TITLE
Missing const qualifiers in AcquisitionModel and Operator methods added.

### DIFF
--- a/src/common/include/sirf/common/Operator.h
+++ b/src/common/include/sirf/common/Operator.h
@@ -6,8 +6,8 @@ namespace sirf {
 	template<class Vector>
 	class Operator {
 	public:
-		virtual std::shared_ptr<Vector> apply(Vector& v) = 0;
-		std::shared_ptr<Vector> operator()(Vector& v)
+		virtual std::shared_ptr<Vector> apply(const Vector& v) = 0;
+		std::shared_ptr<Vector> operator()(const Vector& v)
 		{
 			return apply(v);
 		}

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -1957,7 +1957,7 @@ CFImage CoilSensitivitiesVector::get_csm_as_cfimage(const KSpaceSubset::TagType 
     throw LocalisedException("No coilmap with this tag was in the coilsensitivity container.",   __FILE__, __LINE__);
 }
 
-void CoilSensitivitiesVector::forward(GadgetronImageData& img, GadgetronImageData& combined_img)const
+void CoilSensitivitiesVector::forward(GadgetronImageData& img, const GadgetronImageData& combined_img)const
 {
     if(combined_img.items() != this->items() )
         throw LocalisedException("The number of coilmaps does not equal the number of images to which they should be applied to.",   __FILE__, __LINE__);
@@ -1974,12 +1974,12 @@ void CoilSensitivitiesVector::forward(GadgetronImageData& img, GadgetronImageDat
     this->coilchannels_from_combined_image(img, combined_img);
 }
 
-void CoilSensitivitiesVector::coilchannels_from_combined_image(GadgetronImageData& img, GadgetronImageData& combined_img) const
+void CoilSensitivitiesVector::coilchannels_from_combined_image(GadgetronImageData& img, const GadgetronImageData& combined_img) const
 {
     for(size_t i_img=0; i_img<combined_img.items(); ++i_img)
     {
-        ImageWrap& iw_src = combined_img.image_wrap(i_img);
-        CFImage* ptr_src_img = static_cast<CFImage*>(iw_src.ptr_image());
+        const ImageWrap& iw_src = combined_img.image_wrap(i_img);
+        const CFImage* ptr_src_img = static_cast<const CFImage*>(iw_src.ptr_image());
 
         CFImage coilmap = get_csm_as_cfimage( KSpaceSubset::get_tag_from_img(*ptr_src_img), i_img);
 
@@ -1999,7 +1999,9 @@ void CoilSensitivitiesVector::coilchannels_from_combined_image(GadgetronImageDat
         for( size_t ny=0;ny<Ny ; ny++)
         for( size_t nx=0;nx<Nx ; nx++)
         {
-            (*ptr_dst_img)(nx, ny, nz, nc) =  (*ptr_src_img)(nx, ny, nz, 0) * coilmap(nx, ny, nz, nc);
+            (*ptr_dst_img)(nx, ny, nz, nc) =
+            *(ptr_src_img->getDataPtr() + nx + Nx * (ny + Ny * nz))
+            * coilmap(nx, ny, nz, nc);
         }
 
         img.append(iw_dst);

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -324,7 +324,7 @@ MRAcquisitionData::axpby
 (complex_float_t a, const ISMRMRD::Acquisition& acq_x,
 	complex_float_t b, ISMRMRD::Acquisition& acq_y)
 {
-	complex_float_t* px;
+	const complex_float_t* px;
 	complex_float_t* py;
 	for (px = acq_x.data_begin(), py = acq_y.data_begin();
 		px != acq_x.data_end() && py != acq_y.data_end(); px++, py++) {
@@ -348,10 +348,10 @@ MRAcquisitionData::xapyb
 (const ISMRMRD::Acquisition& acq_x, const ISMRMRD::Acquisition& acq_a,
 	ISMRMRD::Acquisition& acq_y, const ISMRMRD::Acquisition& acq_b)
 {
-	complex_float_t* px;
-	complex_float_t* pa;
+	const complex_float_t* px;
+	const complex_float_t* pa;
 	complex_float_t* py;
-	complex_float_t* pb;
+	const complex_float_t* pb;
 	for (px = acq_x.data_begin(), pa = acq_a.data_begin(),
 		py = acq_y.data_begin(), pb = acq_b.data_begin();
 		px != acq_x.data_end() && pa != acq_a.data_end(),
@@ -365,7 +365,7 @@ void
 MRAcquisitionData::multiply
 (const ISMRMRD::Acquisition& acq_x, ISMRMRD::Acquisition& acq_y)
 {
-	complex_float_t* px;
+	const complex_float_t* px;
 	complex_float_t* py;
 	for (px = acq_x.data_begin(), py = acq_y.data_begin();
 		px != acq_x.data_end() && py != acq_y.data_end(); px++, py++) {
@@ -377,7 +377,7 @@ void
 MRAcquisitionData::divide
 (const ISMRMRD::Acquisition& acq_x, ISMRMRD::Acquisition& acq_y)
 {
-	complex_float_t* px;
+	const complex_float_t* px;
 	complex_float_t* py;
 	for (px = acq_x.data_begin(), py = acq_y.data_begin();
 		px != acq_x.data_end() && py != acq_y.data_end(); px++, py++) {
@@ -389,8 +389,8 @@ complex_float_t
 MRAcquisitionData::dot
 (const ISMRMRD::Acquisition& acq_a, const ISMRMRD::Acquisition& acq_b)
 {
-	complex_float_t* pa;
-	complex_float_t* pb;
+	const complex_float_t* pa;
+	const complex_float_t* pb;
 	complex_float_t z = 0;
 	for (pa = acq_a.data_begin(), pb = acq_b.data_begin();
 		pa != acq_a.data_end() && pb != acq_b.data_end(); pa++, pb++) {
@@ -402,7 +402,7 @@ MRAcquisitionData::dot
 float 
 MRAcquisitionData::norm(const ISMRMRD::Acquisition& acq_a)
 {
-	complex_float_t* pa;
+	const complex_float_t* pa;
 	float r = 0;
 	for (pa = acq_a.data_begin(); pa != acq_a.data_end(); pa++) {
 		complex_float_t z = std::conj(*pa) * (*pa);

--- a/src/xGadgetron/cGadgetron/gadgetron_x.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_x.cpp
@@ -420,7 +420,7 @@ MRAcquisitionModel::set_up(shared_ptr<MRAcquisitionData> sptr_ac,
 }
 
 void
-MRAcquisitionModel::fwd(GadgetronImageData& ic, CoilSensitivitiesVector& cc,
+MRAcquisitionModel::fwd(const GadgetronImageData& ic, CoilSensitivitiesVector& cc,
 	MRAcquisitionData& ac)
 {
     GadgetronImagesVector images_channelresolved;

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_data_containers.h
@@ -1297,12 +1297,12 @@ namespace sirf {
             GadgetronImagesVector::get_image_dimensions(num_csm, dim);
         }
 
-        void forward(GadgetronImageData& img, GadgetronImageData& combined_img)const;
+        void forward(GadgetronImageData& img, const GadgetronImageData& combined_img)const;
         void backward(GadgetronImageData& combined_img, const GadgetronImageData& img)const;
 
     protected:
 
-        void coilchannels_from_combined_image(GadgetronImageData& img, GadgetronImageData& combined_img) const;
+        void coilchannels_from_combined_image(GadgetronImageData& img, const GadgetronImageData& combined_img) const;
         void combine_images_with_coilmaps(GadgetronImageData& combined_img, const GadgetronImageData& img) const;
 
         void calculate_csm(ISMRMRD::NDArray<complex_float_t>& cm, ISMRMRD::NDArray<float>& img, ISMRMRD::NDArray<complex_float_t>& csm);

--- a/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
+++ b/src/xGadgetron/cGadgetron/include/sirf/Gadgetron/gadgetron_x.h
@@ -376,7 +376,7 @@ namespace sirf {
 		public:
 			BFOperator(gadgetron::shared_ptr<MRAcquisitionModel> sptr_am) : sptr_am_(sptr_am) {}
 			virtual gadgetron::shared_ptr<GadgetronImageData>
-				apply(GadgetronImageData& image_data)
+				apply(const GadgetronImageData& image_data)
 			{
 				gadgetron::shared_ptr<MRAcquisitionData> sptr_fwd =
 					sptr_am_->fwd(image_data);
@@ -477,7 +477,7 @@ namespace sirf {
 		
 		// Forward projects the whole ImageContainer using
 		// coil sensitivity maps in the second argument.
-        void fwd(GadgetronImageData& ic, CoilSensitivitiesVector& cc,
+        void fwd(const GadgetronImageData& ic, CoilSensitivitiesVector& cc,
 			MRAcquisitionData& ac);
 
 		// Backprojects the whole AcquisitionContainer using
@@ -487,7 +487,7 @@ namespace sirf {
 
 		// Forward projects the whole ImageContainer using
 		// coil sensitivity maps referred to by sptr_csms_.
-		gadgetron::shared_ptr<MRAcquisitionData> fwd(GadgetronImageData& ic)
+		gadgetron::shared_ptr<MRAcquisitionData> fwd(const GadgetronImageData& ic)
 		{
 
             if (!sptr_acqs_.get())

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -361,7 +361,7 @@ The actual algorithm is described in
 			{
 				num_sub_ = num_sub;
 			}
-			virtual std::shared_ptr<STIRImageData> apply(STIRImageData& image_data)
+			virtual std::shared_ptr<STIRImageData> apply(const STIRImageData& image_data)
 			{
 				std::shared_ptr<STIRAcquisitionData> sptr_fwd =
 					sptr_am_->forward(image_data, sub_num_, num_sub_); // , true);
@@ -506,10 +506,10 @@ The actual algorithm is described in
 			int subset_num, int num_subsets, bool zero = false, bool do_linear_only = false) const;
 
 		// computes and returns back-projected subset of acquisition data 
-		std::shared_ptr<STIRImageData> backward(STIRAcquisitionData& ad,
+		std::shared_ptr<STIRImageData> backward(const STIRAcquisitionData& ad,
 			int subset_num = 0, int num_subsets = 1) const;
 		// puts back-projected subset of acquisition data into image 
-		void backward(STIRImageData& image, STIRAcquisitionData& ad,
+		void backward(STIRImageData& image, const STIRAcquisitionData& ad,
 			int subset_num = 0, int num_subsets = 1) const;
 
 	protected:

--- a/src/xSTIR/cSTIR/stir_x.cpp
+++ b/src/xSTIR/cSTIR/stir_x.cpp
@@ -555,7 +555,7 @@ PETAcquisitionModel::forward(const STIRImageData& image,
 }
 
 std::shared_ptr<STIRImageData> 
-PETAcquisitionModel::backward(STIRAcquisitionData& ad,
+PETAcquisitionModel::backward(const STIRAcquisitionData& ad,
 	int subset_num, int num_subsets) const
 {
 	if (!sptr_image_template_.get())
@@ -567,7 +567,7 @@ PETAcquisitionModel::backward(STIRAcquisitionData& ad,
 }
 
 void
-PETAcquisitionModel::backward(STIRImageData& id, STIRAcquisitionData& ad,
+PETAcquisitionModel::backward(STIRImageData& id, const STIRAcquisitionData& ad,
 	int subset_num, int num_subsets) const
 {
         stir::shared_ptr<Image3DF> sptr_im = id.data_sptr();


### PR DESCRIPTION
## Changes in this pull request

Forward/backprojected object should not be modified and hence must have `const` qualifier, same for the argument of `Operator::apply`.

## Testing performed

All relevant tests passed.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This is a preparatory step before tackling #1182.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
