### PR TITLE
Allow STIR output file format par files with/out spaces

### DIFF
--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -1032,17 +1032,18 @@ namespace sirf {
 
 			If "" is passed as argument for format_file, the default format will be used.
 
-			An example is given below for writing the image in the nifti format. STIR uses
+			An example is given below for writing the image in the nifti format (when using the
+                        `.nii` extension or when not specifying an extension). STIR uses
 			ITK to do this, so ensure that STIR is built with ITK if you wish to use it.
 			\verbatim
-			OutputFileFormat Parameters:=
+			Output File Format Parameters:=
 				output file format type := ITK
 				ITK Output File Format Parameters:=
 				number format := float
 				number_of_bytes_per_pixel:=4
 				default extension:=.nii
 				End ITK Output File Format Parameters:=
-		   End:=
+		        End:=
 		   \endverbatim
 		*/
 		virtual void write(const std::string& filename, const std::string& format_file) const;

--- a/src/xSTIR/cSTIR/stir_data_containers.cpp
+++ b/src/xSTIR/cSTIR/stir_data_containers.cpp
@@ -432,12 +432,16 @@ STIRImageData::write(const std::string &filename, const std::string &format_file
 
     if (!format_file.empty()) {
         KeyParser parser;
+        // STIR format
+        parser.add_start_key("Output File Format Parameters");
+        // old SIRF format, still accepted
         parser.add_start_key("OutputFileFormat Parameters");
         parser.add_parsing_key("output file format type", &format_sptr);
         parser.add_stop_key("END");
         parser.parse(format_file.c_str());
         if(is_null_ptr(format_sptr))
-            throw std::runtime_error("STIRImageData::write: Parsing of output format file (" + format_file + ") failed "
+            throw std::runtime_error("STIRImageData::write: Parsing of output format file (" + format_file + ") failed.\n"
+                                     "STIR should have written a warning message why (if you don't see it, redirect warnings to a file using MessageRedirector)\n"
                                      "(see examples/parameter_files/STIR_output_file_format_xxx.par for help).");
     }
     if(is_null_ptr(format_sptr))


### PR DESCRIPTION
STIR isn't consistent if it wants spaces in the first line of a par file, so now we accept both "output file format parameters :=" and "outputfileformat parameters :="

Also improved error message a bit.

Fixes #1196
