### PR TITLE
[CMAKE] default DISABLE_MATLAB to ON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## xx.xx.xx
+
+* CMake/building:
+  - default `DISABLE_MATLAB` to `ON` as our Matlab support is out-of-date and could
+  generate conflicts with Python shared libraries.
+
 ## v3.5.0
 
 * GitHub Action: remove temporarily the Ubuntu 20.04 build, #1178

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ else(DISABLE_PYTHON)
 endif(DISABLE_PYTHON)
 
 
-option(DISABLE_Matlab "Disable building SIRF matlab support" OFF)
+option(DISABLE_Matlab "Disable building SIRF matlab support" ON)
 if (DISABLE_Matlab)
   message(STATUS "Matlab support disabled")
 else(DISABLE_Matlab)


### PR DESCRIPTION
our Matlab support is out-of-date and could generate conflicts with Python shared libraries.
