### PR TITLE
Sorted out allocate methods (CIL/SIRF compatibility)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
 ```
   with importing via `importlib.import_module` thus getting rid of Codacy complaints about undefined modules.
 
+* Python interfaces for the reconstruction engines:
+  - Several allocate methods in STIR.py, Gadgetron.py and Reg.py are replaced with just one allocate in DataContainer class that does not copy data between Python and C++.
+  - `return None` in the method `Datacontainer.shape()` replaced with more Pythonesque `return (0,)`.
+
 ## v3.5.0
 
 * GitHub Action: remove temporarily the Ubuntu 20.04 build, #1178

--- a/src/Registration/pReg/Reg.py
+++ b/src/Registration/pReg/Reg.py
@@ -303,25 +303,6 @@ class NiftiImageData(SIRF.ImageData):
             image.handle, self.handle))
         return image
 
-    def allocate(self, value=0, **kwargs):
-        """Alias to get_uniform_copy for CIL/SIRF compatibility."""
-        if value in ['random', 'random_int']:
-            out = self.deep_copy()
-            shape = out.as_array().shape
-            seed = kwargs.get('seed', None)
-            if seed is not None:
-                numpy.random.seed(seed)
-            if value == 'random':
-                out.fill(numpy.random.random_sample(shape))
-            elif value == 'random_int':
-                max_value = kwargs.get('max_value', 100)
-                out.fill(numpy.random.randint(max_value, size=shape))
-        else:
-            out = self.deep_copy()
-            out *= 0
-            out.fill(value * numpy.ones_like(out.as_array()))
-        return out
-
     def as_array(self):
         """Get data as numpy array."""
         if self.handle is None:

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -155,16 +155,13 @@ class DataContainer(ABC):
         y.fill(value)
         return y
 
-    def fill(self, value=0):
-        return
-
     def allocate(self, value=0, **kwargs):
         """Allocates a copy of self and fills with values
 
         CIL/SIRF compatibility
         """
-        out = self.clone()
         if value in ['random', 'random_int']:
+            out = self.get_uniform_copy()
             shape = out.shape
             seed = kwargs.get('seed', None)
             if seed is not None:
@@ -174,10 +171,8 @@ class DataContainer(ABC):
             elif value == 'random_int':
                 max_value = kwargs.get('max_value', 100)
                 out.fill(numpy.random.randint(max_value,size=shape))
-        elif value is None:
-            out.fill(0)
         else:
-            out.fill(value)
+            out = self.get_uniform_copy(value)
         return out
 
     def write(self, filename):
@@ -568,7 +563,7 @@ class DataContainer(ABC):
 
     @property
     def size(self):
-        '''Returns the size of the object data.'''
+        '''Returns the number of elements in the object data.'''
         if self.is_empty():
             return 0
         return numpy.prod(self.dimensions())

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -558,7 +558,7 @@ class DataContainer(ABC):
         '''Returns the shape of the object data
         '''
         if self.is_empty():
-            return None
+            return (0,)
         return self.dimensions()
 
     @property

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -158,6 +158,14 @@ class DataContainer(ABC):
     def allocate(self, value=0, **kwargs):
         """Allocates a copy of self and fills with values
 
+        value: Python float or str
+            float: the value to fill with
+            'random': fill with random values ranging between 0 1nd 1 generated
+                by numpy.random.random_sample, optionally using seed provided by
+                kwarg 'seed'
+            'random_int': fill with random integers ranging between 0 and the
+                value optionally provided by kwarg 'max_value' (by default, 100)
+
         CIL/SIRF compatibility
         """
         if value in ['random', 'random_int']:

--- a/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
+++ b/src/xGadgetron/cGadgetron/gadgetron_data_containers.cpp
@@ -185,8 +185,8 @@ MRAcquisitionData::get_acquisitions_dimensions(size_t ptr_dim) const
     int* dim = (int*)ptr_dim;
 
     ISMRMRD::Acquisition acq;
-    int ns;
-    int nc;
+    int ns = 0;
+    int nc = 0;
     int num_acq = 0;
     for (int i = 0; i < na; ++i)
     {

--- a/src/xGadgetron/pGadgetron/Gadgetron.py
+++ b/src/xGadgetron/pGadgetron/Gadgetron.py
@@ -505,27 +505,6 @@ class ImageData(SIRF.ImageData):
                                 suptitle=title, \
                                 show=(t == ni) and not postpone)
             f = t
-    def allocate(self, value=0, **kwargs):
-        '''Method to allocate an ImageData and set its values
-        
-        CIL/SIRF compatibility
-        '''
-        if value in ['random', 'random_int']:
-            out = self.clone()
-            shape = out.as_array().shape
-            seed = kwargs.get('seed', None)
-            if seed is not None:
-                numpy.random.seed(seed)
-            if value == 'random':
-                out.fill(numpy.random.random_sample(shape))
-            elif value == 'random_int':
-                max_value = kwargs.get('max_value', 100)
-                out.fill(numpy.random.randint(max_value,size=shape))
-        else:
-            out = self.clone()
-            tmp = value * numpy.ones(out.as_array().shape)
-            out.fill(tmp)
-        return out
 
     def print_header(self, im_num):
         """Print the header of one of the images. zero based."""
@@ -1176,28 +1155,6 @@ class AcquisitionData(DataContainer):
                                 show = (t == ns) and not postpone)
             f = t
     
-    def allocate(self, value=0, **kwargs):
-        '''Method to allocate an AcquisitionData and set its values
-        
-        CIL/SIRF compatibility
-        '''
-        if value in ['random', 'random_int']:
-            out = self.clone()
-            shape = out.as_array().shape
-            seed = kwargs.get('seed', None)
-            if seed is not None:
-                numpy.random.seed(seed)
-            if value == 'random':
-                out.fill(numpy.random.random_sample(shape))
-            elif value == 'random_int':
-                max_value = kwargs.get('max_value', 100)
-                out.fill(numpy.random.randint(max_value,size=shape))
-        else:
-            out = self.clone()
-            tmp = value * numpy.ones(out.as_array().shape)
-            out.fill(tmp)
-        return out
-
     @property
     def shape(self):
         return self.dimensions()

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -643,28 +643,6 @@ class ImageData(SIRF.ImageData):
                           suptitle=title, show=(t == ni))
             f = t
 
-    def allocate(self, value=0, **kwargs):
-        """Alias to get_uniform_copy for CIL/SIRF compatibility."""
-        if value in ['random', 'random_int']:
-            out = self.get_uniform_copy()
-            shape = out.as_array().shape
-            seed = kwargs.get('seed', None)
-            if seed is not None:
-                numpy.random.seed(seed)
-            if value == 'random':
-                out.fill(numpy.random.random_sample(shape))
-            elif value == 'random_int':
-                max_value = kwargs.get('max_value', 100)
-                out.fill(numpy.random.randint(max_value, size=shape))
-        elif value is None:
-            if self.is_empty():
-                out = self.get_uniform_copy(0)
-            else:
-                out = self.copy()
-        else:
-            out = self.get_uniform_copy(value)
-        return out
-
     def zoom_image(self, zooms=(1., 1., 1.), offsets_in_mm=(0., 0., 0.),
                    size=(-1, -1, -1), scaling='preserve_sum'):
         """
@@ -1393,28 +1371,6 @@ class AcquisitionData(DataContainer):
                 xlabel='tang.pos', ylabel='view',
                 suptitle=title, show=(t == ns))
             f = t
-
-    def allocate(self, value=0, **kwargs):
-        """Alias to get_uniform_copy.
-
-        CIL/SIRF compatibility
-        """
-        if value in ['random', 'random_int']:
-            out = self.get_uniform_copy()
-            shape = out.as_array().shape
-            seed = kwargs.get('seed', None)
-            if seed is not None:
-                numpy.random.seed(seed)
-            if value == 'random':
-                out.fill(numpy.random.random_sample(shape))
-            elif value == 'random_int':
-                max_value = kwargs.get('max_value', 100)
-                out.fill(numpy.random.randint(max_value,size=shape))
-        elif value is None:
-            out = self.get_uniform_copy(0)
-        else:
-            out = self.get_uniform_copy(value)
-        return out
 
     def get_info(self):
         """Returns the AcquisitionData's metadata as Python str."""


### PR DESCRIPTION
## Changes in this pull request

Several `allocate` methods in `STIR.py`, `Gadgetron.py` and `Reg.py` are replaced with just one `allocate` in `DataContainer` class that does not copy data between Python and C++.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1212

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
