### PR TITLE
Fixed a bug in NiftiImageData.cpp causing segfault

### DIFF
--- a/src/Registration/cReg/NiftiImageData.cpp
+++ b/src/Registration/cReg/NiftiImageData.cpp
@@ -220,7 +220,7 @@ void NiftiImageData<dataType>::construct_NiftiImageData_from_complex_im_real_com
 
     auto &it_in = in_sptr->begin();
     auto &it_out = out_sptr->begin();
-    for (; it_in!=in_sptr->end(); ++it_in, ++it_out)
+    for (; it_out != out_sptr->end(); ++it_in, ++it_out)
         *it_out = (*it_in).complex_float().real();
 }
 
@@ -235,7 +235,7 @@ void NiftiImageData<dataType>::construct_NiftiImageData_from_complex_im_imag_com
 
     auto &it_in = in_sptr->begin();
     auto &it_out = out_sptr->begin();
-    for (; it_in!=in_sptr->end(); ++it_in, ++it_out)
+    for (; it_out != out_sptr->end(); ++it_in, ++it_out)
         *it_out = (*it_in).complex_float().imag();
 }
 


### PR DESCRIPTION
## Changes in this pull request

Fixed a bug in `NiftiImageData.cpp` that caused segfault.

## Testing performed

Tested on the code provided by @paskino in #1225.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1225.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
