### PR TITLE
fix STIR HDF5

### DIFF
--- a/src/xSTIR/cSTIR/stir_x.cpp
+++ b/src/xSTIR/cSTIR/stir_x.cpp
@@ -35,6 +35,7 @@ using namespace ecat;
 using namespace sirf;
 
 #if defined(HAVE_HDF5)
+blabla error
 #include "stir/IO/GEHDF5Wrapper.h"
 #include "stir/data/SinglesRatesFromGEHDF5.h"
 #include "stir/recon_buildblock/BinNormalisationFromGEHDF5.h"


### PR DESCRIPTION
We're using `#ifdef HAVE_HDF5` but it should be `STIR_built_with_HDF5`. On my local machine, `HAVE_HDF5` is defined, although I cannot find where, so it was enabled, but on GHA it probably isn't.

I'll test that first. Then replace.
