### PR TITLE
CMake improvements when coping with old Gadgetron

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## vx.x.x
+
+* CMake/building:
+  - add `DISABLE_Gadgetron_TOOLBOXES` option (defaults to `OFF`) to be
+    able to cope with compilation problems with older Gadgetron versions.
+
 ## v3.6.0
 
 * PET:

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -35,13 +35,13 @@ if ((NOT DISABLE_STIR) AND (NOT DISABLE_Gadgetron) AND (NOT DISABLE_Registration
   MESSAGE(STATUS "Registration, ISMRMRD and STIR (with ITK) have been built.")
   target_link_libraries(csirf PUBLIC iutilities csyn)
 else()
-  MESSAGE(STATUS "Either Registration or ISMRMRD or STIR (with ITK) have not been built.")
+  MESSAGE(STATUS "Either Registration or ISMRMRD/Gadgetron or STIR (with ITK) have not been built.")
   add_library(Syn syn_utilities.cpp)
   target_include_directories(Syn PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>"
   )
   target_include_directories(Syn PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../xGadgetron/cGadgetron/include/>$<INSTALL_INTERFACE:include>"
   )
   target_link_libraries(Syn PUBLIC cgadgetron cstir Reg)
   target_link_libraries(csirf PUBLIC iutilities Syn)

--- a/src/xGadgetron/cGadgetron/CMakeLists.txt
+++ b/src/xGadgetron/cGadgetron/CMakeLists.txt
@@ -40,38 +40,43 @@ endif()
 
 set(CGADGETRON_SOURCES cgadgetron.cpp gadgetron_x.cpp gadgetron_data_containers.cpp gadgetron_client.cpp
     gadgetron_fftw.cpp TrajectoryPreparation.cpp FourierEncoding.cpp)
-    
-find_package(gadgetron CONFIG)
-if (gadgetron_FOUND)
-  set (GT_LIBS
-    Gadgetron::gadgetron_toolbox_cpucore
-    Gadgetron::gadgetron_toolbox_cpufft
-    Gadgetron::gadgetron_toolbox_cpunfft
-    Gadgetron::gadgetron_toolbox_log
-    )
-else()
-  message(WARNING "gadgetron-config.cmake was not found. Setting gadgetron_DIR if you do have it. Alternatively, maybe you have an old Gadgetron version. We'll try to find some toolbox libraries by hand.")
-  find_library( GT_CPUCORE NAMES gadgetron_toolbox_cpucore
+
+option(DISABLE_Gadgetron_TOOLBOXES "Disable use of Gadgetron toolboxes" OFF)
+  
+if (NOT DISABLE_Gadgetron_TOOLBOXES)
+  find_package(gadgetron CONFIG)
+  if (gadgetron_FOUND)
+    set (GT_LIBS
+      Gadgetron::gadgetron_toolbox_cpucore
+      Gadgetron::gadgetron_toolbox_cpufft
+      Gadgetron::gadgetron_toolbox_cpunfft
+      Gadgetron::gadgetron_toolbox_log
+      )
+  else()
+    message(WARNING "gadgetron-config.cmake was not found. Setting gadgetron_DIR if you do have it. Alternatively, maybe you have an old Gadgetron version. We'll try to find some toolbox libraries by hand.")
+    find_library( GT_CPUCORE NAMES gadgetron_toolbox_cpucore
                 NAMES_PER_DIR
                 PATHS ${CMAKE_INSTALL_PREFIX}
                 )
-  find_library( GT_FFT NAMES gadgetron_toolbox_cpufft
+    find_library( GT_FFT NAMES gadgetron_toolbox_cpufft
                 NAMES_PER_DIR
                 PATHS ${CMAKE_INSTALL_PREFIX}
                 )
-  find_library( GT_NFFT NAMES gadgetron_toolbox_cpunfft
+    find_library( GT_NFFT NAMES gadgetron_toolbox_cpunfft
                 NAMES_PER_DIR
                 PATHS ${CMAKE_INSTALL_PREFIX}
                 )
-  find_library( GT_LOG NAMES gadgetron_toolbox_log
+    find_library( GT_LOG NAMES gadgetron_toolbox_log
                 NAMES_PER_DIR
                 PATHS ${CMAKE_INSTALL_PREFIX}
                 )
 
-  if (GT_CPUCORE AND GT_FFT AND GT_NFFT AND GT_LOG)
-    set (GT_LIBS ${GT_CPUCORE} ${GT_FFT} ${GT_NFFT} ${GT_LOG} )
+    if (GT_CPUCORE AND GT_FFT AND GT_NFFT AND GT_LOG)
+      set (GT_LIBS ${GT_CPUCORE} ${GT_FFT} ${GT_NFFT} ${GT_LOG} )
+    endif()
   endif()
-endif()
+
+endif() # NOT DISABLE_Gadgetron_TOOLBOXES
 
 if(GT_LIBS)
     MESSAGE(STATUS "The Gadgetron toolboxes required for radial gridding were found. Non-cartesian encoding will be compiled.")
@@ -101,16 +106,15 @@ if(GT_LIBS)
       endif()
 else()
     set(GADGETRON_TOOLBOXES_AVAILABLE FALSE)
-    MESSAGE(WARNING "The Gadgetron Toolboxes required for radial gridding were NOT FOUND. Non-cartesian encoding will NOT BE compiled.")
+    if (NOT DISABLE_Gadgetron_TOOLBOXES)
+      MESSAGE(WARNING "The Gadgetron Toolboxes required for radial gridding were NOT FOUND. Non-cartesian encoding will NOT BE compiled.")
+    else()
+      MESSAGE(STATUS "The Gadgetron Toolboxes required for radial gridding were disabled. Non-cartesian encoding will NOT BE compiled.")
+    endif()
     add_library(cgadgetron ${CGADGETRON_SOURCES})
 endif()
 
-set (cGadgetron_INCLUDE_DIR "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>")
-target_include_directories(cgadgetron PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>$<INSTALL_INTERFACE:include>")
-# copy to parent scope
-#set (cGadgetron_INCLUDE_DIR "${cGadgetron_INCLUDE_DIR}" PARENT_SCOPE)
-
-target_include_directories(cgadgetron PUBLIC "${cGadgetron_INCLUDE_DIR}")
+target_include_directories(cgadgetron PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>$<INSTALL_INTERFACE:include>")
 target_include_directories(cgadgetron PRIVATE "${FFTW3_INCLUDE_DIR}")
 target_include_directories(cgadgetron PUBLIC "${ISMRMRD_INCLUDE_DIR}")
 


### PR DESCRIPTION
- Add option `DISABLE_Gadgetron_TOOLBOXES`.
- Set include path ok