### PR TITLE
Added optional argument out in all gradient-computing methods

### DIFF
--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -1317,12 +1317,12 @@ cSTIR_computePriorGradient(void* ptr_p, void* ptr_i, void* ptr_g)
 
 extern "C"
 void*
-cSTIR_PLSPriorGradient(void* ptr_p, int dir)
+cSTIR_PLSPriorAnatomicalGradient(void* ptr_p, int dir)
 {
 	try {
 		PLSPrior<float>& prior = objectFromHandle<PLSPrior<float> >(ptr_p);
 		auto sptr_im = prior.get_anatomical_grad_sptr(dir);
-        auto sptr_id = std::make_shared<STIRImageData>(*sptr_im);
+		auto sptr_id = std::make_shared<STIRImageData>(*sptr_im);
 		return newObjectHandle(sptr_id);
 	}
 	CATCH;

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -1188,6 +1188,33 @@ cSTIR_objectiveFunctionGradient(void* ptr_f, void* ptr_i, int subset)
 
 extern "C"
 void*
+cSTIR_computeObjectiveFunctionGradient(void* ptr_f, void* ptr_i, int subset, void* ptr_g)
+{
+	try {
+		ObjectiveFunction3DF& fun = objectFromHandle< ObjectiveFunction3DF>(ptr_f);
+		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_i);
+		STIRImageData& gd = objectFromHandle<STIRImageData>(ptr_g);
+		Image3DF& image = id.data();
+		Image3DF& grad = gd.data();
+		if (subset >= 0)
+			fun.compute_sub_gradient(grad, image, subset);
+		else {
+			int nsub = fun.get_num_subsets();
+			grad.fill(0.0);
+			shared_ptr<STIRImageData> sptr_sub(new STIRImageData(image));
+			Image3DF& subgrad = sptr_sub->data();
+			for (int sub = 0; sub < nsub; sub++) {
+				fun.compute_sub_gradient(subgrad, image, sub);
+				grad += subgrad;
+			}
+		}
+		return (void*) new DataHandle;
+	}
+	CATCH;
+}
+
+extern "C"
+void*
 cSTIR_objectiveFunctionGradientNotDivided(void* ptr_f, void* ptr_i, int subset)
 {
 	try {
@@ -1200,6 +1227,24 @@ cSTIR_objectiveFunctionGradientNotDivided(void* ptr_f, void* ptr_i, int subset)
 		fun.compute_sub_gradient_without_penalty_plus_sensitivity
 			(grad, image, subset);
 		return newObjectHandle(sptr);
+	}
+	CATCH;
+}
+
+extern "C"
+void*
+cSTIR_computeObjectiveFunctionGradientNotDivided(void* ptr_f, void* ptr_i, int subset, void* ptr_g)
+{
+	try {
+		PoissonLogLhLinModMean3DF& fun =
+			objectFromHandle<PoissonLogLhLinModMean3DF>(ptr_f);
+		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_i);
+		STIRImageData& gd = objectFromHandle<STIRImageData>(ptr_g);
+		Image3DF& image = id.data();
+		Image3DF& grad = gd.data();
+		fun.compute_sub_gradient_without_penalty_plus_sensitivity
+			(grad, image, subset);
+		return (void*) new DataHandle;
 	}
 	CATCH;
 }
@@ -1250,6 +1295,22 @@ cSTIR_priorGradient(void* ptr_p, void* ptr_i)
 		Image3DF& grad = sptr->data();
 		prior.compute_gradient(grad, image);
 		return newObjectHandle(sptr);
+	}
+	CATCH;
+}
+
+extern "C"
+void*
+cSTIR_computePriorGradient(void* ptr_p, void* ptr_i, void* ptr_g)
+{
+	try {
+		Prior3DF& prior = objectFromHandle<Prior3DF>(ptr_p);
+		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_i);
+		STIRImageData& gd = objectFromHandle<STIRImageData>(ptr_g);
+		Image3DF& image = id.data();
+		Image3DF& grad = gd.data();
+		prior.compute_gradient(grad, image);
+		return (void*) new DataHandle;
 	}
 	CATCH;
 }

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
@@ -143,17 +143,22 @@ extern "C" {
 
 	// Objective function methods
 	void* cSTIR_setupObjectiveFunction(void* ptr_r, void* ptr_i);
-	void*	cSTIR_subsetSensitivity(void* ptr_f, int subset);
+	void* cSTIR_subsetSensitivity(void* ptr_f, int subset);
 	void* cSTIR_objectiveFunctionValue(void* ptr_f, void* ptr_i);
 	void* cSTIR_objectiveFunctionGradient
 		(void* ptr_f, void* ptr_i, int subset);
+    void* cSTIR_computeObjectiveFunctionGradient
+        (void* ptr_f, void* ptr_i, int subset, void* ptr_g);
 	void* cSTIR_objectiveFunctionGradientNotDivided
 		(void* ptr_f, void* ptr_i, int subset);
+    void* cSTIR_computeObjectiveFunctionGradientNotDivided
+        (void* ptr_f, void* ptr_i, int subset, void* ptr_g);
 
 	// Prior methods
 	void* cSTIR_setupPrior(void* ptr_p, void* ptr_i);
 	void* cSTIR_priorValue(void* ptr_p, void* ptr_i);
 	void* cSTIR_priorGradient(void* ptr_p, void* ptr_i);
+    void* cSTIR_computePriorGradient(void* ptr_p, void* ptr_i, void* ptr_g);
 	void* cSTIR_PLSPriorGradient(void* ptr_p, int dir);
 
 	// Image methods

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
@@ -158,8 +158,8 @@ extern "C" {
 	void* cSTIR_setupPrior(void* ptr_p, void* ptr_i);
 	void* cSTIR_priorValue(void* ptr_p, void* ptr_i);
 	void* cSTIR_priorGradient(void* ptr_p, void* ptr_i);
-    void* cSTIR_computePriorGradient(void* ptr_p, void* ptr_i, void* ptr_g);
-	void* cSTIR_PLSPriorGradient(void* ptr_p, int dir);
+	void* cSTIR_computePriorGradient(void* ptr_p, void* ptr_i, void* ptr_g);
+	void* cSTIR_PLSPriorAnatomicalGradient(void* ptr_p, int dir);
 
 	// Image methods
 	void* cSTIR_getImageDimensions(const void* ptr, PTR_INT ptr_data);

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -2307,7 +2307,7 @@ class Prior(object):
         """Returns the value of the prior (alias of get_value())."""
         return self.get_value(image)
 
-    def get_gradient(self, image, out=None):
+    def get_gradient(self, image, out=None, **kwargs):
         """Returns gradient of the prior.
 
         Returns the value of the gradient of the prior for the specified image.
@@ -2324,7 +2324,7 @@ class Prior(object):
         check_status(out.handle)
         return out
 
-    def gradient(self, image, out=None):
+    def gradient(self, image, out=None, **kwargs):
         """Returns the gradient of the prior (alias of get_gradient())."""
 
         return self.get_gradient(image, out)
@@ -2577,7 +2577,7 @@ class PLSPrior(Prior):
             image = ImageData()
         else:
             image = out
-        image.handle = pystir.cSTIR_PLSPriorGradient(self.handle, direction)
+        image.handle = pystir.cSTIR_PLSPriorAnatomicalGradient(self.handle, direction)
         check_status(image.handle)
         return image
 

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -33,7 +33,7 @@ from numbers import Integral, Number
 from deprecation import deprecated
 
 from sirf.Utilities import show_2D_array, show_3D_array, error, check_status, \
-     try_calling, assert_validity, \
+     try_calling, assert_validity, assert_validities, \
      cpp_int_dtype, cpp_int_array, \
      examples_data_path, existing_filepath, pTest
 from sirf import SIRF
@@ -2315,12 +2315,14 @@ class Prior(object):
         """
         assert_validity(image, ImageData)
         if out is None:
-            grad = ImageData()
+            out = ImageData()
+        if out.handle is None:
+            out.handle = pystir.cSTIR_priorGradient(self.handle, image.handle)
         else:
-            grad = out
-        grad.handle = pystir.cSTIR_priorGradient(self.handle, image.handle)
-        check_status(grad.handle)
-        return grad
+            assert_validities(image, out)
+            pystir.cSTIR_computePriorGradient(self.handle, image.handle, out.handle)
+        check_status(out.handle)
+        return out
 
     def gradient(self, image, out=None):
         """Returns the gradient of the prior (alias of get_gradient())."""
@@ -2704,13 +2706,14 @@ class ObjectiveFunction(object):
         """
         assert_validity(image, ImageData)
         if out is None:
-            grad = ImageData()
+            out = ImageData()
+        if out.handle is None:
+            out.handle = pystir.cSTIR_objectiveFunctionGradient(self.handle, image.handle, subset)
         else:
-            grad = out
-        grad.handle = pystir.cSTIR_objectiveFunctionGradient(
-            self.handle, image.handle, subset)
-        check_status(grad.handle)
-        return grad
+            assert_validities(image, out)
+            pystir.cSTIR_computeObjectiveFunctionGradient(self.handle, image.handle, subset, out.handle)
+        check_status(out.handle)
+        return out
 
     def get_gradient(self, image, out=None):
         """Returns the gradient of the objective function on specified image.
@@ -2784,13 +2787,16 @@ class PoissonLogLikelihoodWithLinearModelForMean(ObjectiveFunction):
         """
         assert_validity(image, ImageData)
         if out is None:
-            grad = ImageData()
+            out = ImageData()
+        if out.handle is None:
+            out.handle = pystir.cSTIR_objectiveFunctionGradientNotDivided(
+                self.handle, image.handle, subset)
         else:
-            grad = out
-        grad.handle = pystir.cSTIR_objectiveFunctionGradientNotDivided(
-            self.handle, image.handle, subset)
-        check_status(grad.handle)
-        return grad
+            assert_validities(image, out)
+            pystir.cSTIR_computeObjectiveFunctionGradientNotDivided(
+                self.handle, image.handle, subset, out.handle)
+        check_status(out.handle)
+        return out
 
 
 class PoissonLogLikelihoodWithLinearModelForMeanAndProjData(

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -2314,11 +2314,12 @@ class Prior(object):
         image: ImageData object
         """
         assert_validity(image, ImageData)
-        grad = ImageData()
+        if out is None:
+            grad = ImageData()
+        else:
+            grad = out
         grad.handle = pystir.cSTIR_priorGradient(self.handle, image.handle)
         check_status(grad.handle)
-        if out is not None:
-            out.fill(grad)
         return grad
 
     def gradient(self, image, out=None):
@@ -2570,11 +2571,12 @@ class PLSPrior(Prior):
 
     def get_anatomical_grad(self, direction, out=None):
         """Returns anatomical gradient."""
-        image = ImageData()
+        if out is None:
+            image = ImageData()
+        else:
+            image = out
         image.handle = pystir.cSTIR_PLSPriorGradient(self.handle, direction)
         check_status(image.handle)
-        if out is not None:
-            out.fill(image)
         return image
 
     def set_anatomical_filename(self, filename):
@@ -2701,12 +2703,13 @@ class ObjectiveFunction(object):
         subset: Python integer scalar
         """
         assert_validity(image, ImageData)
-        grad = ImageData()
+        if out is None:
+            grad = ImageData()
+        else:
+            grad = out
         grad.handle = pystir.cSTIR_objectiveFunctionGradient(
             self.handle, image.handle, subset)
         check_status(grad.handle)
-        if out is not None:
-            out.fill(grad)
         return grad
 
     def get_gradient(self, image, out=None):
@@ -2714,7 +2717,7 @@ class ObjectiveFunction(object):
 
         image: ImageData object
         """
-        return self.gradient(image, out)
+        return self.gradient(image, -1, out)
 
     def get_subset_gradient(self, image, subset, out=None):
         """Returns the value of the additive component of the gradient
@@ -2780,12 +2783,13 @@ class PoissonLogLikelihoodWithLinearModelForMean(ObjectiveFunction):
         acquisition data.
         """
         assert_validity(image, ImageData)
-        grad = ImageData()
+        if out is None:
+            grad = ImageData()
+        else:
+            grad = out
         grad.handle = pystir.cSTIR_objectiveFunctionGradientNotDivided(
             self.handle, image.handle, subset)
         check_status(grad.handle)
-        if out is not None:
-            out.fill(grad)
         return grad
 
 

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -2307,7 +2307,7 @@ class Prior(object):
         """Returns the value of the prior (alias of get_value())."""
         return self.get_value(image)
 
-    def get_gradient(self, image):
+    def get_gradient(self, image, out=None):
         """Returns gradient of the prior.
 
         Returns the value of the gradient of the prior for the specified image.
@@ -2317,12 +2317,14 @@ class Prior(object):
         grad = ImageData()
         grad.handle = pystir.cSTIR_priorGradient(self.handle, image.handle)
         check_status(grad.handle)
+        if out is not None:
+            out.fill(grad)
         return grad
 
-    def gradient(self, image):
+    def gradient(self, image, out=None):
         """Returns the gradient of the prior (alias of get_gradient())."""
 
-        return self.get_gradient(image)
+        return self.get_gradient(image, out)
 
     def set_up(self, image):
         """Sets up."""
@@ -2566,11 +2568,13 @@ class PLSPrior(Prior):
         check_status(image.handle)
         return image
 
-    def get_anatomical_grad(self, direction):
+    def get_anatomical_grad(self, direction, out=None):
         """Returns anatomical gradient."""
         image = ImageData()
         image.handle = pystir.cSTIR_PLSPriorGradient(self.handle, direction)
         check_status(image.handle)
+        if out is not None:
+            out.fill(image)
         return image
 
     def set_anatomical_filename(self, filename):
@@ -2686,7 +2690,7 @@ class ObjectiveFunction(object):
         """
         return self.value(image)
 
-    def gradient(self, image, subset=-1):
+    def gradient(self, image, subset=-1, out=None):
         """Returns the value of the additive component of the gradient
 
         of this objective function on the specified image corresponding to the
@@ -2701,16 +2705,18 @@ class ObjectiveFunction(object):
         grad.handle = pystir.cSTIR_objectiveFunctionGradient(
             self.handle, image.handle, subset)
         check_status(grad.handle)
+        if out is not None:
+            out.fill(grad)
         return grad
 
-    def get_gradient(self, image):
+    def get_gradient(self, image, out=None):
         """Returns the gradient of the objective function on specified image.
 
         image: ImageData object
         """
-        return self.gradient(image)
+        return self.gradient(image, out)
 
-    def get_subset_gradient(self, image, subset):
+    def get_subset_gradient(self, image, subset, out=None):
         """Returns the value of the additive component of the gradient
 
         of this objective function on <image> corresponding to the specified
@@ -2718,7 +2724,7 @@ class ObjectiveFunction(object):
         image: ImageData object
         subset: Python integer scalar
         """
-        return self.gradient(image, subset)
+        return self.gradient(image, subset, out)
 
     @abc.abstractmethod
     def get_subset_sensitivity(self, subset):
@@ -2767,7 +2773,7 @@ class PoissonLogLikelihoodWithLinearModelForMean(ObjectiveFunction):
         check_status(ss.handle)
         return ss
 
-    def get_backprojection_of_acquisition_ratio(self, image, subset):
+    def get_backprojection_of_acquisition_ratio(self, image, subset, out=None):
         """Returns backprojection of measured to estimated acquisition ratio.
 
         Returns the back-projection of the ratio of the measured and estimated
@@ -2778,6 +2784,8 @@ class PoissonLogLikelihoodWithLinearModelForMean(ObjectiveFunction):
         grad.handle = pystir.cSTIR_objectiveFunctionGradientNotDivided(
             self.handle, image.handle, subset)
         check_status(grad.handle)
+        if out is not None:
+            out.fill(grad)
         return grad
 
 


### PR DESCRIPTION
## Changes in this pull request

Added optional argument `out` in all gradient-computing methods for compatibility with CIL.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1242.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
