### PR TITLE
sapyb to return even if out is not None

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## vx.x.x
 
 * CMake/building:
+  - Python `sapyb` returns the output even if it is pre-allocated 
   - add `DISABLE_Gadgetron_TOOLBOXES` option (defaults to `OFF`) to be
     able to cope with compilation problems with older Gadgetron versions.
 

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -480,7 +480,7 @@ class DataContainer(ABC):
 
         if out is None:
             check_status(z.handle)
-            return z
+        return z
 
     def power(self, other, out=None):
         '''Power function for DataContainers


### PR DESCRIPTION
## Changes in this pull request

With CIL https://github.com/TomographicImaging/CIL/pull/1742 `sapyb` needs to return even if the output is pre-allocated

## Testing performed

Reintroduced `test_SIRF.py` from CIL.
https://github.com/SyneRBI/SIRF-SuperBuild/pull/897

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [ ] The code builds and runs on my machine
- [x] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
