### PR TITLE
use more STIR container operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## v3.8.0
 
+* SIRF/STIR (PET and SPECT)
+  - use direct STIR operations for arrays, potentially resulting in speed-up when using STIR 6.2 or later.
+
 * CMake/building:
 - set CMP0074 policy to NEW, i.e. honour <packagename>_ROOT env variables
 
@@ -11,7 +14,7 @@
   - Python `sapyb` returns the output even if it is pre-allocated
   - Python add `min()` to `DataContainer`
 
-* PET:
+* SIRF/STIR (PET and SPECT):
   - implemented basic-functionality list-mode data class in C++ and Python
   - added objective function type for list-mode reconstruction
   - added new demo script for the reconstruction from list-mode data

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_data_containers.h
@@ -808,11 +808,15 @@ namespace sirf {
                 return this->STIRAcquisitionData::norm();
 
             // do it
+#if STIR_VERSION <= 060100
             double t = 0.0;
             auto iter = pd_ptr->begin();
 			for (; iter != pd_ptr->end(); ++iter)
 				t += (*iter) * (*iter);
 			return std::sqrt((float)t);
+#else
+                        return static_cast<float>(pd_ptr->norm());
+#endif
         }
         virtual void dot(const DataContainer& a_x, void* ptr) const
         {


### PR DESCRIPTION
use STIR's `find_min()`, `find_max()`, `sum()`, `norm()` and `xapyb()` when available.

Addresses #1259 (but doesn't use += etc yet)