### PR TITLE
CMake] add STIR_REGISTRIES to Reg executables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,44 +46,6 @@ else()
 endif()
 
 
-
-##########################################################################
-#                             Registration                               #
-##########################################################################
-option(DISABLE_Registration "Disable building the SIRF registration package" OFF)
-if (DISABLE_Registration)
-  message(STATUS "Registration support disabled.")
-  set(SPM_BOOL_STR "0" PARENT_SCOPE)
-  set(SIRF_BUILT_WITH_REGISTRATION False PARENT_SCOPE)
-else()
-  FIND_PACKAGE(NIFTYREG 1.5.61 REQUIRED)
-  # NIFTYREG
-  FOREACH(NR_lib ${NIFTYREG_LIBRARIES})
-    find_library(${NR_lib}_full_path "${NR_lib}" "${NIFTYREG_LIBRARY_DIRS}")
-    if(NOT ${NR_lib}_full_path)
-      message(FATAL_ERROR "${NR_lib} not found")
-    endif()
-    SET(NR_libs_full_path "${NR_libs_full_path};${${NR_lib}_full_path}")
-  ENDFOREACH()
-  # If niftyreg was bulit with OpenMP
-  if (NIFTYREG_BUILT_WITH_OPENMP)
-    find_package(OpenMP REQUIRED)
-    if (OpenMP_CXX_FOUND)
-      SET(NR_libs_full_path "${NR_libs_full_path};OpenMP::OpenMP_CXX")
-    endif()
-  endif()
-  # If niftyreg was bulit with CUDA
-  if (NIFTYREG_BUILT_WITH_CUDA)
-    find_package(CUDA REQUIRED)
-    SET(NR_libs_full_path "${NR_libs_full_path};${CUDA_CUDA_LIBRARY};${CUDA_CUDART_LIBRARY}")
-  endif()
-  ADD_SUBDIRECTORY(Registration)
-  set(SPM_BOOL_STR ${SPM_BOOL_STR} PARENT_SCOPE)
-  set(SIRF_BUILT_WITH_REGISTRATION TRUE PARENT_SCOPE)
-endif()
-
-
-
 ##########################################################################
 #                                 STIR                                   #
 ##########################################################################
@@ -125,6 +87,42 @@ endif()
 set(NiftyPET_BOOL_STR ${NiftyPET_BOOL_STR} PARENT_SCOPE)
 set(Parallelproj_BOOL_STR ${Parallelproj_BOOL_STR} PARENT_SCOPE)
 
+
+
+##########################################################################
+#                             Registration                               #
+##########################################################################
+option(DISABLE_Registration "Disable building the SIRF registration package" OFF)
+if (DISABLE_Registration)
+  message(STATUS "Registration support disabled.")
+  set(SPM_BOOL_STR "0" PARENT_SCOPE)
+  set(SIRF_BUILT_WITH_REGISTRATION False PARENT_SCOPE)
+else()
+  FIND_PACKAGE(NIFTYREG 1.5.61 REQUIRED)
+  # NIFTYREG
+  FOREACH(NR_lib ${NIFTYREG_LIBRARIES})
+    find_library(${NR_lib}_full_path "${NR_lib}" "${NIFTYREG_LIBRARY_DIRS}")
+    if(NOT ${NR_lib}_full_path)
+      message(FATAL_ERROR "${NR_lib} not found")
+    endif()
+    SET(NR_libs_full_path "${NR_libs_full_path};${${NR_lib}_full_path}")
+  ENDFOREACH()
+  # If niftyreg was bulit with OpenMP
+  if (NIFTYREG_BUILT_WITH_OPENMP)
+    find_package(OpenMP REQUIRED)
+    if (OpenMP_CXX_FOUND)
+      SET(NR_libs_full_path "${NR_libs_full_path};OpenMP::OpenMP_CXX")
+    endif()
+  endif()
+  # If niftyreg was bulit with CUDA
+  if (NIFTYREG_BUILT_WITH_CUDA)
+    find_package(CUDA REQUIRED)
+    SET(NR_libs_full_path "${NR_libs_full_path};${CUDA_CUDA_LIBRARY};${CUDA_CUDART_LIBRARY}")
+  endif()
+  ADD_SUBDIRECTORY(Registration)
+  set(SPM_BOOL_STR ${SPM_BOOL_STR} PARENT_SCOPE)
+  set(SIRF_BUILT_WITH_REGISTRATION TRUE PARENT_SCOPE)
+endif()
 
 ##########################################################################
 #                             Synergistic                                #

--- a/src/Registration/cReg/CMakeLists.txt
+++ b/src/Registration/cReg/CMakeLists.txt
@@ -115,7 +115,8 @@ SET(REG_executables
     )
 
 FOREACH(elem ${REG_executables})
-    ADD_EXECUTABLE(${elem} ${elem}.cpp)
+    # Note: adding STIR_REGISTRIES to avoid linking errors (and give extra IO capabilities)
+    ADD_EXECUTABLE(${elem} ${elem}.cpp ${STIR_REGISTRIES})
     TARGET_LINK_LIBRARIES(${elem} LINK_PUBLIC Reg)
     INSTALL(TARGETS ${elem} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 ENDFOREACH(elem ${REG_executables})

--- a/src/Registration/cReg/tests/CMakeLists.txt
+++ b/src/Registration/cReg/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-#========================================================================
+##========================================================================
 # Author: Richard Brown
 # Copyright 2016 - 2019 University College London
 #
@@ -17,7 +17,9 @@
 # test Reg
 ########################################################################################
 # Create an executable
-ADD_EXECUTABLE (REG_TEST_CPLUSPLUS test_cReg.cpp)
+
+# Note: adding STIR_REGISTRIES to avoid linking errors
+ADD_EXECUTABLE (REG_TEST_CPLUSPLUS test_cReg.cpp ${STIR_REGISTRIES})
 SET_TARGET_PROPERTIES (REG_TEST_CPLUSPLUS
     PROPERTIES FOLDER ${CMAKE_INSTALL_PREFIX}/bin
     INSTALL_NAME_DIR "Reg")


### PR DESCRIPTION
I experienced linking problems with STIR (probably related to its use of "interdependent" libraries.
Adding `STIR_REGISTRIES` as dependency fixed it (and shouldn't do any harm).

To do that, I had to interchange the order of the ADD_SUBDIRECTORY statements (i.e. include STIR before Reg).

Note that Actions will likely fail until #1267 is fixed.
