### PR TITLE
STIR min/max-scale-factor in ScatterEstimation exposed.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * SIRF/STIR (PET and SPECT)
   - use direct STIR operations for arrays, potentially resulting in speed-up when using STIR 6.2 or later.
+  - added means for setting maximal and minimal value for scale factor in stir::ScatterEstimation
 
 * CMake/building:
 - set CMP0074 policy to NEW, i.e. honour <packagename>_ROOT env variables

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -856,24 +856,27 @@ sirf::cSTIR_setScatterEstimatorParameter
         int value = dataFromHandle<int>(hv);
         obj.set_num_iterations(value);
     }
-    
     else if (sirf::iequals(name, "set_OSEM_num_subiterations"))
     {
         int value = dataFromHandle<int>(hv);
         obj.set_OSEM_num_subiterations(value);
     }
-    
     else if (sirf::iequals(name, "set_OSEM_num_subsets"))
     {
         int value = dataFromHandle<int>(hv);
         obj.set_OSEM_num_subsets(value);
     }
-    
-    
-    
     else if (sirf::iequals(name, "set_output_prefix"))
     {
         obj.set_output_prefix(charDataFromHandle(hv));
+    }
+    else if (sirf::iequals(name, "set_max_scale_value"))
+    {
+        obj.set_max_scale_factor_value(dataFromHandle<float>(hv));
+    }
+    else if (sirf::iequals(name, "set_min_scale_value"))
+    {
+        obj.set_min_scale_factor_value(dataFromHandle<float>(hv));
     }
     else
         return parameterNotFound(name, __FILE__, __LINE__);

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -872,11 +872,11 @@ sirf::cSTIR_setScatterEstimatorParameter
     }
     else if (sirf::iequals(name, "set_max_scale_value"))
     {
-        obj.set_max_scale_factor_value(dataFromHandle<float>(hv));
+        obj.set_max_scale_value(dataFromHandle<float>(hv));
     }
     else if (sirf::iequals(name, "set_min_scale_value"))
     {
-        obj.set_min_scale_factor_value(dataFromHandle<float>(hv));
+        obj.set_min_scale_value(dataFromHandle<float>(hv));
     }
     else
         return parameterNotFound(name, __FILE__, __LINE__);

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -947,6 +947,16 @@ The actual algorithm is described in
           return this->get_reconstruction_method().get_num_subsets();
         }
 
+        void set_max_scale_factor_value(float v)
+        {
+            set_max_scale_value(v);
+        }
+
+        void set_min_scale_factor_value(float v)
+        {
+            set_min_scale_value(v);
+        }
+
         std::shared_ptr<STIRAcquisitionData> get_scatter_estimate(int est_num = -1) const
         {
             if (est_num == -1) // Get the last one

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -947,14 +947,14 @@ The actual algorithm is described in
           return this->get_reconstruction_method().get_num_subsets();
         }
 
-        void set_max_scale_factor_value(float v)
+        void set_max_scale_value(float v)
         {
-            set_max_scale_value(v);
+            stir::ScatterEstimation::set_max_scale_value(v);
         }
 
-        void set_min_scale_factor_value(float v)
+        void set_min_scale_value(float v)
         {
-            set_min_scale_value(v);
+            stir::ScatterEstimation::set_min_scale_value(v);
         }
 
         std::shared_ptr<STIRAcquisitionData> get_scatter_estimate(int est_num = -1) const

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -3614,6 +3614,14 @@ class ScatterEstimator():
         """Set number of iterations of the SSS algorithm to use."""
         parms.set_int_par(self.handle, 'PETScatterEstimator', 'set_num_iterations', v)
 
+    def set_max_scale_value(self, v):
+        """Set maximal scale factor value of the SSS algorithm to use."""
+        parms.set_float_par(self.handle, 'PETScatterEstimator', 'set_max_scale_value', v)
+
+    def set_min_scale_value(self, v):
+        """Set maximal scale factor value of the SSS algorithm to use."""
+        parms.set_float_par(self.handle, 'PETScatterEstimator', 'set_min_scale_value', v)
+
     def set_output_prefix(self, v):
         """
         Set prefix for filenames with scatter estimates.


### PR DESCRIPTION
## Changes in this pull request

Added min/max_scale_factor methods to scatter estimation classes (C++ and Python).

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1270.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
