### PR TITLE
do not run CUDA tests if GPU not available

### DIFF
--- a/src/xSTIR/pSTIR/tests/tests_qp_lc_rdp.py
+++ b/src/xSTIR/pSTIR/tests/tests_qp_lc_rdp.py
@@ -18,7 +18,13 @@ import sirf.STIR
 import sirf.config
 from sirf.Utilities import runner, RE_PYEXT, __license__, examples_data_path, pTest
 __version__ = "2.1.0"
-__author__ = "Imraj Singh, Evgueni Ovtchinnikov, Kris Thielemans"
+__author__ = "Imraj Singh, Evgueni Ovtchinnikov, Kris Thielemans, Edoardo Pasca"
+
+try:
+    subprocess.check_output('nvidia-smi')
+    has_nvidia = True
+except:
+    has_nvidia = False
 
 
 def Hessian_test(test, prior, x, eps=1e-3):
@@ -61,7 +67,7 @@ def test_main(rec=False, verb=False, throw=True):
       for penalisation_factor in [0,1,4]:
         for kappa in [True, False]:
           priors = [sirf.STIR.QuadraticPrior(), sirf.STIR.LogcoshPrior(), sirf.STIR.RelativeDifferencePrior()]
-          if sirf.config.STIR_WITH_CUDA:
+          if sirf.config.STIR_WITH_CUDA and has_nvidia:
               priors.append(sirf.STIR.CudaRelativeDifferencePrior())
           for prior in priors:
             if kappa:


### PR DESCRIPTION
## Changes in this pull request
Skips the RDP GPU test if GPU is not installed, detected by running `nvidia-smi` during test.

## Testing performed
CI

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- closes https://github.com/SyneRBI/SIRF/issues/1278

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
