### PR TITLE
Code overlaps in computing gradients of objective functions removed.

### DIFF
--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -1198,26 +1198,13 @@ void*
 cSTIR_objectiveFunctionGradient(void* ptr_f, void* ptr_i, int subset)
 {
 	try {
-		ObjectiveFunction3DF& fun = objectFromHandle< ObjectiveFunction3DF>(ptr_f);
+		xSTIR_ObjFun3DF& fun = objectFromHandle<xSTIR_ObjFun3DF>(ptr_f);
 		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_i);
-		Image3DF& image = id.data();
-		STIRImageData* ptr_id = new STIRImageData(image);
-		shared_ptr<STIRImageData> sptr(ptr_id);
-		Image3DF& grad = sptr->data();
-		if (subset >= 0)
-			fun.compute_sub_gradient(grad, image, subset);
-		else {
-			int nsub = fun.get_num_subsets();
-			grad.fill(0.0);
-			STIRImageData* ptr_id = new STIRImageData(image);
-			shared_ptr<STIRImageData> sptr_sub(ptr_id);
-			Image3DF& subgrad = sptr_sub->data();
-			for (int sub = 0; sub < nsub; sub++) {
-				fun.compute_sub_gradient(subgrad, image, sub);
-				grad += subgrad;
-			}
-		}
-		return newObjectHandle(sptr);
+		STIRImageData* ptr_gd = new STIRImageData(id);
+		shared_ptr<STIRImageData> sptr_gd(ptr_gd);
+		STIRImageData& gd = *sptr_gd;
+		fun.compute_gradient(id, subset, gd);
+		return newObjectHandle(sptr_gd);
 	}
 	CATCH;
 }
@@ -1227,23 +1214,10 @@ void*
 cSTIR_computeObjectiveFunctionGradient(void* ptr_f, void* ptr_i, int subset, void* ptr_g)
 {
 	try {
-		ObjectiveFunction3DF& fun = objectFromHandle< ObjectiveFunction3DF>(ptr_f);
+		xSTIR_ObjFun3DF& fun = objectFromHandle<xSTIR_ObjFun3DF>(ptr_f);
 		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_i);
 		STIRImageData& gd = objectFromHandle<STIRImageData>(ptr_g);
-		Image3DF& image = id.data();
-		Image3DF& grad = gd.data();
-		if (subset >= 0)
-			fun.compute_sub_gradient(grad, image, subset);
-		else {
-			int nsub = fun.get_num_subsets();
-			grad.fill(0.0);
-			shared_ptr<STIRImageData> sptr_sub(new STIRImageData(image));
-			Image3DF& subgrad = sptr_sub->data();
-			for (int sub = 0; sub < nsub; sub++) {
-				fun.compute_sub_gradient(subgrad, image, sub);
-				grad += subgrad;
-			}
-		}
+		fun.compute_gradient(id, subset, gd);
 		return (void*) new DataHandle;
 	}
 	CATCH;

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -1198,12 +1198,10 @@ void*
 cSTIR_objectiveFunctionGradient(void* ptr_f, void* ptr_i, int subset)
 {
 	try {
-		xSTIR_ObjFun3DF& fun = objectFromHandle<xSTIR_ObjFun3DF>(ptr_f);
-		STIRImageData& id = objectFromHandle<STIRImageData>(ptr_i);
-		STIRImageData* ptr_gd = new STIRImageData(id);
-		shared_ptr<STIRImageData> sptr_gd(ptr_gd);
-		STIRImageData& gd = *sptr_gd;
-		fun.compute_gradient(id, subset, gd);
+		auto& fun = objectFromHandle<xSTIR_ObjFun3DF>(ptr_f);
+		auto& id = objectFromHandle<STIRImageData>(ptr_i);
+		auto sptr_gd = std::make_shared<STIRImageData>(id);
+		fun.compute_gradient(id, subset, *sptr_gd);
 		return newObjectHandle(sptr_gd);
 	}
 	CATCH;

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -1107,6 +1107,11 @@ The actual algorithm is described in
 
 	class xSTIR_GeneralisedObjectiveFunction3DF : public ObjectiveFunction3DF {
 	public:
+		//! computes the gradientof an objective function
+		/*! if the subset number is non-negative, computes the gradient of
+			this objective function for that subset, otherwise computes
+			the sum of gradients for all subsets
+		*/
 		void compute_gradient(const STIRImageData& id, int subset, STIRImageData& gd)
 		{
 			const Image3DF& image = id.data();

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -1105,11 +1105,28 @@ The actual algorithm is described in
 		}
 	};
 
-	class xSTIR_GeneralisedObjectiveFunction3DF :
-		public stir::GeneralisedObjectiveFunction < Image3DF > {
+	class xSTIR_GeneralisedObjectiveFunction3DF : public ObjectiveFunction3DF {
 	public:
+		void compute_gradient(const STIRImageData& id, int subset, STIRImageData& gd)
+		{
+			const Image3DF& image = id.data();
+			Image3DF& grad = gd.data();
+			if (subset >= 0)
+				compute_sub_gradient(grad, image, subset);
+			else {
+				int nsub = get_num_subsets();
+				grad.fill(0.0);
+				shared_ptr<STIRImageData> sptr_sub(new STIRImageData(image));
+				Image3DF& subgrad = sptr_sub->data();
+				for (int sub = 0; sub < nsub; sub++) {
+					compute_sub_gradient(subgrad, image, sub);
+					grad += subgrad;
+				}
+			}
+		}
+
 		void multiply_with_Hessian(Image3DF& output, const Image3DF& curr_image_est,
-            const Image3DF& input, const int subset) const
+			const Image3DF& input, const int subset) const
 		{
 			output.fill(0.0);
 			if (subset >= 0)
@@ -1120,13 +1137,9 @@ The actual algorithm is described in
 				}
 			}
 		}
-
-//		bool post_process() {
-//			return post_processing();
-//		}
 	};
 
-	//typedef xSTIR_GeneralisedObjectiveFunction3DF ObjectiveFunction3DF;
+	typedef xSTIR_GeneralisedObjectiveFunction3DF xSTIR_ObjFun3DF;
 
 	class xSTIR_PoissonLogLikelihoodWithLinearModelForMeanAndProjData3DF :
 		public stir::PoissonLogLikelihoodWithLinearModelForMeanAndProjData < Image3DF > {


### PR DESCRIPTION
## Changes in this pull request

Got rid of code overlaps in computing gradients of objective functions.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

fixes #1252

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
