### PR TITLE
Error raised in AcquisitionSensitivityModel.[un]normalise methods applied to a read-only object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 * SIRF/STIR
   - `ScatterEstimation` has extra methods that allow setting masks for the tail-fitting
+  - Error raised in `AcquisitionSensitivityModel.[un]normalise` methods applied to a read-only object.
+
 
 
 ## v3.8.1

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -1685,6 +1685,9 @@ class AcquisitionSensitivityModel(object):
         if self.handle is None:
             raise AssertionError()
         assert_validity(ad, AcquisitionData)
+        if ad.read_only:
+            raise error(
+                'Cannot normalise a read-only object, consider using method invert instead')
         try_calling(pystir.cSTIR_applyAcquisitionSensitivityModel(
             self.handle, ad.handle, 'normalise'))
 
@@ -1697,6 +1700,9 @@ class AcquisitionSensitivityModel(object):
         if self.handle is None:
             raise AssertionError()
         assert_validity(ad, AcquisitionData)
+        if ad.read_only:
+            raise error(
+                'Cannot normalise a read-only object, consider using method forward instead')
         try_calling(pystir.cSTIR_applyAcquisitionSensitivityModel(
             self.handle, ad.handle, 'unnormalise'))
 

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -1702,7 +1702,7 @@ class AcquisitionSensitivityModel(object):
         assert_validity(ad, AcquisitionData)
         if ad.read_only:
             raise error(
-                'Cannot normalise a read-only object, consider using method forward instead')
+                'Cannot unnormalise a read-only object, consider using method forward instead')
         try_calling(pystir.cSTIR_applyAcquisitionSensitivityModel(
             self.handle, ad.handle, 'unnormalise'))
 


### PR DESCRIPTION
## Changes in this pull request

Error raised in `AcquisitionSensitivityModel.[un]normalise` methods if applied to a read-only object.

## Testing performed

Yes

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Quick fix for issue 1298

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [x] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
