### PR TITLE
Poisson noise generation script for PETRIC2

### DIFF
--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -82,6 +82,9 @@ def main():
     print('raw data: %s' % raw_data_file)
     acq_data = pet.AcquisitionData(raw_data_file)
 
+    png = pet.PoissonNoiseGenerator(10, True)
+    png.seed(2)
+
     # copy the acquisition data into a Python array and display
     dim = acq_data.dimensions()
     print('data dimensions: %d x %d x %d x %d' % dim)

--- a/examples/Python/PET/acquisition_data.py
+++ b/examples/Python/PET/acquisition_data.py
@@ -82,8 +82,14 @@ def main():
     print('raw data: %s' % raw_data_file)
     acq_data = pet.AcquisitionData(raw_data_file)
 
-    png = pet.PoissonNoiseGenerator(10, True)
-    png.seed(2)
+    png = pet.PoissonNoiseGenerator(0.1)
+    png.seed(1)
+    noise = png.generate(acq_data)
+    dim_noise = noise.dimensions()
+    print(f'acquisition data norm: {acq_data.norm()}')
+    print(f'noise norm: {noise.norm()}')
+    if show_plot:
+        noise.show(range(dim_noise[1]//4))
 
     # copy the acquisition data into a Python array and display
     dim = acq_data.dimensions()

--- a/src/xSTIR/cSTIR/cstir.cpp
+++ b/src/xSTIR/cSTIR/cstir.cpp
@@ -204,6 +204,8 @@ void* cSTIR_newObject(const char* name)
                   return NEW_OBJECT_HANDLE(PETScatterEstimator);
 		if (sirf::iequals(name, "SeparableGaussianImageFilter"))
 			return NEW_OBJECT_HANDLE(xSTIR_SeparableGaussianImageFilter);
+                if (sirf::iequals(name, "PoissonNoiseGenerator"))
+                  return NEW_OBJECT_HANDLE(PoissonNoiseGenerator);
 		return unknownObject("object", name, __FILE__, __LINE__);
 	}
 	CATCH;
@@ -290,6 +292,8 @@ void* cSTIR_setParameter
                         return cSTIR_setScatterSimulatorParameter(hs, name, hv);
                 else if(sirf::iequals(obj, "PETScatterEstimator"))
                         return cSTIR_setScatterEstimatorParameter(hs, name, hv);
+                else if(sirf::iequals(obj, "PoissonNoiseGenerator"))
+                        return cSTIR_setPoissonNoiseGeneratorParameter(hs, name, hv);
 		else
 			return unknownObject("object", obj, __FILE__, __LINE__);
 	}
@@ -360,6 +364,8 @@ void* cSTIR_parameter(const void* ptr, const char* obj, const char* name)
 			return cSTIR_FBP2DParameter(handle, name);
                 else if(sirf::iequals(obj, "PETScatterEstimator"))
                         return cSTIR_ScatterEstimatorParameter(handle, name);
+//                else if(sirf::iequals(obj, "PoissonNoiseGenerator"))
+//                        return cSTIR_PoissonNoiseGeneratorParameter(handle, name);
 		return unknownObject("object", obj, __FILE__, __LINE__);
 	}
 	CATCH;
@@ -609,6 +615,31 @@ void* cSTIR_applyImageDataProcessor(const void* ptr_p, void* ptr_i)
 		Image3DF& image = id.data();
 		processor.apply(image);
 		return (void*) new DataHandle;
+	}
+	CATCH;
+}
+
+extern "C"
+void* cSTIR_createPoissonNoiseGenerator(const float scaling_factor, const bool preserve_mean)
+{
+	try {
+		shared_ptr<PoissonNoiseGenerator> 
+			sptr(new PoissonNoiseGenerator(scaling_factor, preserve_mean));
+		return newObjectHandle(sptr);
+	}
+	CATCH;
+}
+
+extern "C"
+void* cSTIR_generatePoissonNoise(const void* ptr_gen, const void* ptr_input)
+{
+	try {
+		PoissonNoiseGenerator& generator =
+			objectFromHandle<PoissonNoiseGenerator>(ptr_gen);
+		STIRAcquisitionData& input = objectFromHandle<STIRAcquisitionData>(ptr_input);
+		std::shared_ptr<STIRAcquisitionData> sptr_output = input.new_acquisition_data();
+		generator.generate_random(*sptr_output, input);
+		return newObjectHandle(sptr_output);
 	}
 	CATCH;
 }

--- a/src/xSTIR/cSTIR/cstir_p.cpp
+++ b/src/xSTIR/cSTIR/cstir_p.cpp
@@ -920,6 +920,17 @@ sirf::cSTIR_ScatterEstimatorParameter(DataHandle* hp, const char* name)
 }
 
 void*
+sirf::cSTIR_setPoissonNoiseGeneratorParameter
+(const DataHandle *hp, const char* name, const DataHandle* hv)
+{
+    PoissonNoiseGenerator& obj =
+            objectFromHandle<PoissonNoiseGenerator>(hp);
+    if (sirf::iequals(name, "seed"))
+        obj.seed(dataFromHandle<int>(hv));
+    return new DataHandle;
+}
+
+void*
 sirf::cSTIR_setGeneralisedObjectiveFunctionParameter
 (DataHandle* hp, const char* name, const DataHandle* hv)
 {

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir.h
@@ -76,6 +76,13 @@ extern "C" {
 		(const void* ptr_src, const char* src);
 	void* cSTIR_createPETAttenuationModel
 		(const void* ptr_img, const void* ptr_am);
+
+	// Poisson noise generator
+	void* cSTIR_createPoissonNoiseGenerator
+		(const float scaling_factor, const bool preserve_mean);
+	void* cSTIR_generatePoissonNoise
+		(const void* ptr_gen, const void* ptr_input);
+
 	void* cSTIR_computeACF
 		(const void* ptr_sino, const void* ptr_att, void* ptr_acf, void* ptr_iacf);
 	void* cSTIR_chainPETAcquisitionSensitivityModels

--- a/src/xSTIR/cSTIR/include/sirf/STIR/cstir_p.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/cstir_p.h
@@ -168,6 +168,10 @@ namespace sirf {
                 cSTIR_ScatterEstimatorParameter
                 (DataHandle* hp, const char* name);
 
+        void*
+                cSTIR_setPoissonNoiseGeneratorParameter
+                (const DataHandle *hp, const char* name, const DataHandle* hv);
+
 	void*
 		cSTIR_setGeneralisedObjectiveFunctionParameter
 		(DataHandle* hp, const char* name, const DataHandle* hv);

--- a/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
+++ b/src/xSTIR/cSTIR/include/sirf/STIR/stir_x.h
@@ -41,6 +41,7 @@ limitations under the License.
 #include "sirf/STIR/stir_data_containers.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h"
 #include "stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h"
+#include "stir/GeneralisedPoissonNoiseGenerator.h"
 
 #define MIN_BIN_EFFICIENCY 1.0e-20f
 //#define MIN_BIN_EFFICIENCY 1.0e-6f
@@ -107,6 +108,27 @@ namespace sirf {
 		//shared_ptr<stir::ChainedBinNormalisation> norm_;
 	};
 
+	class PoissonNoiseGenerator {
+	public:
+		//! Constructor intialises the random number generator with a fixed seed
+		PoissonNoiseGenerator(const float scaling_factor = 1.0F, const bool preserve_mean = false)
+		{
+			gpng_ = stir::shared_ptr<stir::GeneralisedPoissonNoiseGenerator>
+				(new GeneralisedPoissonNoiseGenerator(scaling_factor, preserve_mean));
+		}
+		//! The seed value for the random number generator
+		void seed(unsigned int s)
+		{
+			gpng_->seed(s);
+		}
+		void generate_random(STIRAcquisitionData& output, const STIRAcquisitionData& input)
+		{
+			gpng_->generate_random(*output.data(), *input.data());
+		}
+
+	protected:
+		stir::shared_ptr<stir::GeneralisedPoissonNoiseGenerator> gpng_;
+	};
 	
         /*!
 	\ingroup PET

--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -1625,6 +1625,26 @@ class ListmodeToSinograms(object):
         return v
 
 
+class PoissonNoiseGenerator(object):
+    """
+    Class that generates Poisson noise.
+    """
+
+    def __init__(self, scaling_factor=1.0, preserve_mean=False):
+        self.name = "PoissonNoiseGenerator"
+        self.handle = pystir.cSTIR_createPoissonNoiseGenerator(scaling_factor, preserve_mean)
+        check_status(self.handle)
+
+    def seed(self, s):
+        parms.set_int_par(self.handle, self.name, 'seed', s)
+
+    def generate(self, input):
+        output = AcquisitionData()
+        output.handle = pystir.cSTIR_generatePoissonNoise(self.handle, input.handle)
+        check_status(output.handle)
+        return output
+
+
 class AcquisitionSensitivityModel(object):
     """
     Class that handles PET scanner detector efficiencies and attenuation.


### PR DESCRIPTION
## Changes in this pull request

Poisson noise generation script for PETRIC2 to be added.

## Testing performed

A simple example of Poisson noise generation added (temporarily?) to `examples/Python/PET/acquisition_data.py`

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
