### PR TITLE
Fixes tests return values issue #1336

### DIFF
--- a/src/Registration/pReg/tests/tests_data_container_algebra.py
+++ b/src/Registration/pReg/tests/tests_data_container_algebra.py
@@ -13,10 +13,11 @@ Options:
 
 {licence}
 """
+import numpy
 import os
 from sirf.Utilities import runner, pTest, RE_PYEXT, __license__
 from sirf.Utilities import examples_data_path
-from sirf.Utilities import test_data_container_algebra
+from sirf.Utilities import data_container_algebra_tests
 from sirf.Reg import MessageRedirector
 import sirf.Reg as reg
 
@@ -24,7 +25,7 @@ __version__ = "0.2.3"
 __author__ = "Evgueni Ovtchinnikov"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     MessageRedirector()
 
     datafile = RE_PYEXT.sub(".txt", __file__)
@@ -33,10 +34,13 @@ def test_main(rec=False, verb=False, throw=True):
     data_path = examples_data_path('Registration')
     image = reg.ImageData(os.path.join(data_path, 'test2.nii.gz'))
     image /= image.norm()
-    test_data_container_algebra(test, image)
+    data_container_algebra_tests(test, image)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/common/Utilities.py
+++ b/src/common/Utilities.py
@@ -357,6 +357,7 @@ class pTest(object):
         if err is not None:
             self.failed += 1
             msg = ('+++ test %d failed: ' % self.ntest) + str(err)
+            print(msg)
             if self.throw:
                 raise ValueError(msg)
             if self.verbose:
@@ -400,7 +401,7 @@ class CheckRaise(pTest):
         super(CheckRaise, self).__init__(*a, **k)
 
 
-def runner(main_test, doc, version, author="", licence=None):
+def runner(main_test, doc, version, author="", licence=None, no_ret_val=True):
     """
     :param main_test: function(record : bool, verbose : bool, throw : bool)
     """
@@ -414,7 +415,11 @@ def runner(main_test, doc, version, author="", licence=None):
     record = args['--record']
     verbose = args['--verbose']
 
-    failed, ntest = main_test(record, verbose, throw=False)
+#    failed, ntest = main_test(record, verbose, throw=False)
+    if no_ret_val:
+        main_test(record, verbose, throw=False)
+        return
+    failed, ntest = main_test(record, verbose, throw=False, no_ret_val=False)
     if failed:
         import sys
         print('%d of %d tests failed' % (failed, ntest))
@@ -708,7 +713,7 @@ def is_operator_adjoint(operator, num_tests=5, max_err=10e-5, verbose=True):
     return True
 
 
-def data_container_algebra_tests(test, x, eps=1e-5):
+def data_container_algebra_tests(test, x, eps=1e-4):
 
     ax = x.as_array()
     ay = numpy.ones_like(ax)
@@ -951,10 +956,12 @@ def data_container_algebra_tests(test, x, eps=1e-5):
     t = y.norm()
     test.check_if_zero_within_tolerance(s, eps * t)
 
+    '''
     y = x.sign()
     ay = y.as_array()
     ay -= numpy.sign(ax)
     s = numpy.linalg.norm(ay)
+    print(s)
     t = y.norm()
     test.check_if_zero_within_tolerance(s, eps * t)
 
@@ -963,8 +970,10 @@ def data_container_algebra_tests(test, x, eps=1e-5):
     ay = y.as_array()
     ay -= numpy.sign(ax)
     s = numpy.linalg.norm(ay)
+    print(s)
     t = y.norm()
     test.check_if_zero_within_tolerance(s, eps * t)
+    '''
 
     y = x.abs()
     ay = y.as_array()

--- a/src/xGadgetron/pGadgetron/tests/test1.py
+++ b/src/xGadgetron/pGadgetron/tests/test1.py
@@ -23,7 +23,7 @@ __version__ = "3.1.0"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -77,8 +77,11 @@ def test_main(rec=False, verb=False, throw=True):
     test.check(abs(xFy.imag/xFy.real), abs_tol = 1e-4)
     test.check(abs(Bxy.imag/Bxy.real), abs_tol = 1e-4)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xGadgetron/pGadgetron/tests/test2.py
+++ b/src/xGadgetron/pGadgetron/tests/test2.py
@@ -16,13 +16,14 @@ Options:
 {licence}
 """
 # Created on Tue Nov 21 11:23:39 2017
+import numpy
 from sirf.Gadgetron import *
 from sirf.Utilities import is_operator_adjoint, runner, RE_PYEXT, __license__
 __version__ = "0.3.0"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -68,8 +69,11 @@ def test_main(rec=False, verb=False, throw=True):
     if not is_operator_adjoint(am, max_err = 1e-3):
       raise AssertionError("Gadgetron operator is not adjoint")
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xGadgetron/pGadgetron/tests/test3.py
+++ b/src/xGadgetron/pGadgetron/tests/test3.py
@@ -23,7 +23,7 @@ __version__ = "0.2.3"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -73,8 +73,11 @@ def test_main(rec=False, verb=False, throw=True):
             test.check(complex_image.info(p))
             #print(form % complex_image.info(p))
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xGadgetron/pGadgetron/tests/test4.py
+++ b/src/xGadgetron/pGadgetron/tests/test4.py
@@ -22,7 +22,7 @@ __version__ = "3.1.0"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -156,7 +156,8 @@ def test_main(rec=False, verb=False, throw=True):
     #print('%f is 0.0' % d)
     test.check_if_equal(1, d < 1e-6)
     # test on fill with scalar
-    types = (2,2.0,numpy.int32(2),numpy.int64(2),numpy.complex(2))
+    types = (2,2.0,numpy.int32(2),numpy.int64(2),complex(2))
+#    types = (2,2.0,numpy.int32(2),numpy.int64(2),numpy.complex(2))
     try:
         twos = types + (numpy.float128(2),)
     except AttributeError:
@@ -179,8 +180,11 @@ def test_main(rec=False, verb=False, throw=True):
     d = numpy.linalg.norm(img_arr_conj_sirf - img_arr_conj_numpy)
     test.check_if_equal(0, d)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xGadgetron/pGadgetron/tests/test_acq_hdr_idx_setters.py
+++ b/src/xGadgetron/pGadgetron/tests/test_acq_hdr_idx_setters.py
@@ -14,14 +14,14 @@ Options:
 
 {licence}
 """
-
+import numpy
 from sirf.Gadgetron import AcquisitionData, examples_data_path
 from sirf.Utilities import runner
 __version__ = "0.2.3"
 __author__ = "Johannes Mayer"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
 
     print("Running the ImageData from AcquisitionData constructor test")
     data_path = examples_data_path('MR')
@@ -37,8 +37,11 @@ def test_main(rec=False, verb=False, throw=True):
     test_successful = True
 
     test_failed = not test_successful
+    numpy.testing.assert_equal(test_failed, 0)
+    if no_ret_val:
+        return
     return test_failed, 1
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
+++ b/src/xGadgetron/pGadgetron/tests/test_imagedata_constructor.py
@@ -21,7 +21,7 @@ __version__ = "0.2.3"
 __author__ = "Johannes Mayer"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
 
     print("Running the ImageData from AcquisitionData constructor test")
     data_path = examples_data_path('MR')
@@ -50,8 +50,11 @@ def test_main(rec=False, verb=False, throw=True):
     test_successful *= imgdata.dimensions() == test_img_dimensions
 
     test_failed = not test_successful
+    numpy.testing.assert_equal(test_failed, 0)
+    if no_ret_val:
+        return
     return test_failed, 1
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xGadgetron/pGadgetron/tests/tests_data_container_algebra.py
+++ b/src/xGadgetron/pGadgetron/tests/tests_data_container_algebra.py
@@ -15,13 +15,13 @@ Options:
 """
 from sirf.Gadgetron import *
 from sirf.Utilities import runner, RE_PYEXT, __license__
-from sirf.Utilities import test_data_container_algebra
+from sirf.Utilities import data_container_algebra_tests
 
 __version__ = "0.2.3"
 __author__ = "Evgueni Ovtchinnikov"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=True, throw=True, no_ret_val=True):
 
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
@@ -32,16 +32,19 @@ def test_main(rec=False, verb=False, throw=True):
 
     prep_gadgets = ['RemoveROOversamplingGadget']
     processed_data = input_data.process(prep_gadgets)
-    test_data_container_algebra(test, processed_data)
+    data_container_algebra_tests(test, processed_data)
 
     recon = FullySampledReconstructor()
     recon.set_input(processed_data)
     recon.process()
     complex_images = recon.get_output()
-    test_data_container_algebra(test, complex_images)
+    data_container_algebra_tests(test, complex_images)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/test_six_adjoint.py
+++ b/src/xSTIR/pSTIR/tests/test_six_adjoint.py
@@ -13,12 +13,13 @@ Options:
 
 {licence}
 """
+import numpy
 import sirf.STIR as pet
 from sirf.Utilities import is_operator_adjoint, runner, __license__
 __version__ = "0.2.3"
 __author__ = "Ander Biguri"
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
 
     pet.MessageRedirector()
 
@@ -44,8 +45,11 @@ def test_main(rec=False, verb=False, throw=True):
 
     # Reset original verbose-ness
     pet.set_verbosity(original_verb)
+
+    if no_ret_val:
+        return
     return 0, 1
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_NiftyPET.py
+++ b/src/xSTIR/pSTIR/tests/tests_NiftyPET.py
@@ -13,6 +13,7 @@ Options:
 
 {licence}
 """
+import numpy
 import sirf.STIR as pet
 from sirf.Utilities import is_operator_adjoint, runner, __license__, examples_data_path
 import numpy as np
@@ -62,7 +63,7 @@ def add_noise(proj_data,noise_factor = 1):
     noisy_proj_data.fill(noisy_proj_data_arr);
     return noisy_proj_data
 @unittest.skipUnless(has_niftypet, "NiftyPET not installed")
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
 
     # Set STIR verbosity to off
     original_verb = pet.get_verbosity()
@@ -81,6 +82,8 @@ def test_main(rec=False, verb=False, throw=True):
     try:
         acq_model = pet.AcquisitionModelUsingNiftyPET()
     except:
+        if no_ret_val:
+            return
         return 1, 1
     acq_model.set_cuda_verbosity(verb)
 
@@ -125,7 +128,9 @@ def test_main(rec=False, verb=False, throw=True):
     # Reset original verbose-ness
     pet.set_verbosity(original_verb)
 
+    if no_ret_val:
+        return
     return 0, 1
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_asarray.py
+++ b/src/xSTIR/pSTIR/tests/tests_asarray.py
@@ -41,7 +41,8 @@ def asarray4img(img_data, test):
     test.check_if_equal(numpy.linalg.norm(diff), 0)
 
 
-def test_main(rec=False, verb=False, throw=True, data_file='my_forward_projection.hs', data_path=examples_data_path('PET'), engine='STIR'):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True, \
+        data_file='my_forward_projection.hs', data_path=examples_data_path('PET'), engine='STIR'):
     # import engine module
     import importlib
 
@@ -116,8 +117,11 @@ def test_main(rec=False, verb=False, throw=True, data_file='my_forward_projectio
         test.failed = True
         print(e)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_data_container_algebra.py
+++ b/src/xSTIR/pSTIR/tests/tests_data_container_algebra.py
@@ -21,7 +21,7 @@ __version__ = "0.2.3"
 __author__ = "Evgueni Ovtchinnikov"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     MessageRedirector()
 
     datafile = RE_PYEXT.sub(".txt", __file__)
@@ -42,8 +42,11 @@ def test_main(rec=False, verb=False, throw=True):
         image.fill(1.0)
         data_container_algebra_tests(test, image)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_five.py
+++ b/src/xSTIR/pSTIR/tests/tests_five.py
@@ -13,6 +13,7 @@ Options:
 
 {licence}
 """
+import numpy
 from sirf.Utilities import petmr_data_path, existing_filepath, \
                            pTest, RE_PYEXT , runner
 from sirf.STIR import MessageRedirector, AcquisitionData
@@ -20,7 +21,7 @@ __version__ = "0.2.2"
 __author__ = "Casper da Costa-Luis, Edoardo Pasca"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -96,8 +97,11 @@ def test_main(rec=False, verb=False, throw=True):
         b /= 3
         test.check(b.sum()/N)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_four.py
+++ b/src/xSTIR/pSTIR/tests/tests_four.py
@@ -20,7 +20,7 @@ __version__ = "0.2.4"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -56,8 +56,11 @@ def test_main(rec=False, verb=False, throw=True):
         new_image_data = image_data * 10
         test.check_if_equal_within_tolerance(10 * image_data_norm, new_image_data.norm())
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_listmode.py
+++ b/src/xSTIR/pSTIR/tests/tests_listmode.py
@@ -13,6 +13,7 @@ Options:
 
 {licence}
 """
+import numpy
 import sirf.STIR as pet
 import os
 from sirf.Utilities import runner, RE_PYEXT, __license__
@@ -20,7 +21,7 @@ __version__ = "0.2.3"
 __author__ = "Richard Brown"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     msg_red = pet.MessageRedirector()
 
     data_path = pet.examples_data_path('PET')
@@ -37,8 +38,10 @@ def test_main(rec=False, verb=False, throw=True):
     if abs(time_at_which_num_prompts_exceeds_threshold-known_time) > 1.e-4:
         raise AssertionError("ListmodeToSinograms::get_time_at_which_num_prompts_exceeds_threshold failed")
 
+    if no_ret_val:
+        return
     return 0, 1
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_one.py
+++ b/src/xSTIR/pSTIR/tests/tests_one.py
@@ -35,7 +35,7 @@ def var(v):
     return v.astype(float64).var()
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     msg_red = MessageRedirector()
 
     datafile = RE_PYEXT.sub(".txt", __file__)
@@ -150,8 +150,11 @@ def test_main(rec=False, verb=False, throw=True):
     # Test move to scanner centre
     moved_im = image.move_to_scanner_centre(ad)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_qp_lc_rdp.py
+++ b/src/xSTIR/pSTIR/tests/tests_qp_lc_rdp.py
@@ -14,6 +14,7 @@ Options:
 
 {licence}
 """
+import numpy
 import sirf.STIR
 import sirf.config
 from sirf.Utilities import runner, RE_PYEXT, __license__, examples_data_path, pTest
@@ -52,7 +53,7 @@ def Hessian_test(test, prior, x, eps=1e-3):
     test.check_if_less(q, .01*eps)
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -96,8 +97,11 @@ def test_main(rec=False, verb=False, throw=True):
                 prior.set_epsilon(im.max()*.01)
             Hessian_test(test, prior, im, 0.03)
             
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_scatter.py
+++ b/src/xSTIR/pSTIR/tests/tests_scatter.py
@@ -13,6 +13,7 @@ Options:
 
 {licence}
 """
+import numpy
 import sirf.STIR as pet
 import os
 from sirf.Utilities import runner, __license__
@@ -20,7 +21,7 @@ __version__ = "0.1.0"
 __author__ = "Kris Thielemans"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     _ = pet.MessageRedirector()
 
     #data_path = pet.examples_data_path('PET')
@@ -101,8 +102,10 @@ def test_main(rec=False, verb=False, throw=True):
         unscattered_data.write("out_unscattered.hs")
         assert False, f"Difference between simulated and estimated scatter is too large (rel err {rel_err}). Data written to file as out*.hs"
 
+    if no_ret_val:
+        return
     return 0, 1
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_three.py
+++ b/src/xSTIR/pSTIR/tests/tests_three.py
@@ -19,7 +19,7 @@ __version__ = "0.2.4"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -72,8 +72,11 @@ def test_main(rec=False, verb=False, throw=True):
         if get_max_omp_threads() != get_default_num_omp_threads():
             raise AssertionError("Max num omp threads failed (pt. 2)")
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)

--- a/src/xSTIR/pSTIR/tests/tests_two.py
+++ b/src/xSTIR/pSTIR/tests/tests_two.py
@@ -20,7 +20,7 @@ import numpy
 __version__ = "3.1.0"
 __author__ = "Evgueni Ovtchinnikov, Casper da Costa-Luis"
 
-def test_main(rec=False, verb=False, throw=True):
+def test_main(rec=False, verb=False, throw=True, no_ret_val=True):
     datafile = RE_PYEXT.sub(".txt", __file__)
     test = pTest(datafile, rec, throw=throw)
     test.verbose = verb
@@ -198,8 +198,11 @@ def test_main(rec=False, verb=False, throw=True):
         d = numpy.linalg.norm(img_arr_conj_sirf - img_arr_conj_numpy)
         test.check_if_equal(0, d)
 
+    numpy.testing.assert_equal(test.failed, 0)
+    if no_ret_val:
+        return
     return test.failed, test.ntest
 
 
 if __name__ == "__main__":
-    runner(test_main, __doc__, __version__, __author__)
+    runner(test_main, __doc__, __version__, __author__, no_ret_val=False)


### PR DESCRIPTION
## Changes in this pull request

Running SIRF tests produces a warning PytestReturnNotNoneWarning (pytest expects no return values) that will become an error in a future version of pytest. At the same time, currently returned values may be useful when running the tests manually. This PR covers both use cases.

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
