### PR TITLE
fix STIR.ObjectiveFunction.accumulate_Hessian_times_input

### DIFF
--- a/src/xSTIR/pSTIR/STIR.py
+++ b/src/xSTIR/pSTIR/STIR.py
@@ -2880,7 +2880,7 @@ class ObjectiveFunction(object):
         """Computes the multiplication of the Hessian at current_estimate with a vector and adds it to output.
         """
         if out is None or out.handle is None:
-            out = input_.clone()
+            out = input_.get_uniform_copy(0.0)
         try_calling(pystir.cSTIR_objectiveFunctionAccumulateHessianTimesInput
             (self.handle, current_estimate.handle, input_.handle, subset, out.handle))
         return out
@@ -2889,7 +2889,7 @@ class ObjectiveFunction(object):
         """Computes the multiplication of the Hessian at current_estimate with a vector.
         """
         if out is None or out.handle is None:
-            out = input_.get_uniform_copy(0.0)
+            out = input_.get_uniform_copy(0.0) # actual value doesn't matter as STIR will overwrite it.
         try_calling(pystir.cSTIR_objectiveFunctionComputeHessianTimesInput
             (self.handle, current_estimate.handle, input_.handle, subset, out.handle))
         return out


### PR DESCRIPTION
Fix Python bug when out=None. The value of the input was used to accumulate to.

Fixes #1343 

@evgueni-ovtchinnikov could you check why our tests didn't catch this?