### PR TITLE
[ci skip] Update test gradient tolerance values in tests

### DIFF
--- a/src/xSTIR/pSTIR/tests/test_ObjectiveFunction.py
+++ b/src/xSTIR/pSTIR/tests/test_ObjectiveFunction.py
@@ -85,7 +85,7 @@ class TestSTIRObjectiveFunction(unittest.TestCase):
     def test_gradient_inplace(self):
         '''Checks that gradient computed in-place returns the same as without in-place.
 
-        Note: the absolute tolerance of the test was increased from the default 0 to 3e-4, see 'test_gradient_out'
+        Note: the absolute tolerance of the test was increased from the default 1e-8 to 3e-4, see 'test_gradient_out'
         '''
         x = self.image
         g1 = self.obj_fun.gradient(x)
@@ -95,7 +95,7 @@ class TestSTIRObjectiveFunction(unittest.TestCase):
     def test_gradient_out(self):
         '''Checks that gradient with 'out' parameter returns the same as without the 'out' parameter.
 
-        Note: the absolute tolerance of the test was increased from the default 0 to 3e-4.
+        Note: the absolute tolerance of the test was increased from the default 1e-8 to 3e-4.
         https://github.com/SyneRBI/SIRF/issues/1349
         '''
         x = self.image


### PR DESCRIPTION
## Changes in this pull request

Update the docstring with the right default value of absolute tolerance of [`allclose`](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html).

## Testing performed
N/A

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

* https://github.com/SyneRBI/SIRF/pull/1355

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
