### PR TITLE
allow namespace packages

### DIFF
--- a/cmake/sirf.__init__.py.in
+++ b/cmake/sirf.__init__.py.in
@@ -1,3 +1,6 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)  # allow namespace packages such as sirf.contrib
+
 __version_major__ = '@VERSION_MAJOR@'
 __version_minor__ = '@VERSION_MINOR@'
 __version_patch__ = '@VERSION_PATCH@'


### PR DESCRIPTION
- references:
  + https://packaging.python.org/en/latest/guides/packaging-namespace-packages/
  + [PEP#420](https://peps.python.org/pep-0420/)
- required by
  + https://github.com/SyneRBI/SIRF-Contribs/pull/29
  + https://github.com/SyneRBI/SIRF-SuperBuild/issues/982 <- https://github.com/SyneRBI/SIRF-SuperBuild/issues/981