### PR TITLE
Add tests for asarray method in test_algebra.py

### DIFF
--- a/src/xGadgetron/pGadgetron/tests/test_algebra.py
+++ b/src/xGadgetron/pGadgetron/tests/test_algebra.py
@@ -21,7 +21,7 @@ import os
 import unittest
 import sirf.Gadgetron as mr
 from sirf.Utilities import  examples_data_path, DataContainerAlgebraTests
-from sirf.STIR import ContiguousError
+from sirf.SIRF import ContiguousError
 
 
 class TestGadgetronAcquisitionDataAlgebra(unittest.TestCase, DataContainerAlgebraTests):

--- a/src/xGadgetron/pGadgetron/tests/test_algebra.py
+++ b/src/xGadgetron/pGadgetron/tests/test_algebra.py
@@ -67,8 +67,8 @@ class TestGadgetronImageDataAlgebra(unittest.TestCase, DataContainerAlgebraTests
 
     def test_asarray_no_copy_throws_ContiguousError(self):
         with self.assertRaises(ContiguousError):
-            a = self.image1.asarray(copy=False)
+            self.image1.asarray(copy=False)
         
     def test_asarray_copy_runs(self):
-        a = self.image1.asarray()
+        self.image1.asarray()
         

--- a/src/xGadgetron/pGadgetron/tests/test_algebra.py
+++ b/src/xGadgetron/pGadgetron/tests/test_algebra.py
@@ -21,7 +21,7 @@ import os
 import unittest
 import sirf.Gadgetron as mr
 from sirf.Utilities import  examples_data_path, DataContainerAlgebraTests
-
+from sirf.STIR import ContiguousError
 
 
 class TestGadgetronAcquisitionDataAlgebra(unittest.TestCase, DataContainerAlgebraTests):
@@ -65,3 +65,10 @@ class TestGadgetronImageDataAlgebra(unittest.TestCase, DataContainerAlgebraTests
         #shutil.rmtree(self.cwd)
         pass
 
+    def test_asarray_no_copy_throws_ContiguousError(self):
+        with self.assertRaises(ContiguousError):
+            a = self.image1.asarray(copy=False)
+        
+    def test_asarray_copy_runs(self):
+        a = self.image1.asarray()
+        

--- a/src/xSTIR/pSTIR/tests/tests_asarray.py
+++ b/src/xSTIR/pSTIR/tests/tests_asarray.py
@@ -15,7 +15,6 @@ Options:
 import numpy
 
 from sirf.STIR import pTest
-from sirf.SIRF import ContiguousError
 from sirf.Utilities import runner, RE_PYEXT, examples_data_path, existing_filepath
 
 __version__ = '0.1.0'

--- a/src/xSTIR/pSTIR/tests/tests_asarray.py
+++ b/src/xSTIR/pSTIR/tests/tests_asarray.py
@@ -14,7 +14,8 @@ Options:
 '''
 import numpy
 
-from sirf.STIR import pTest, ContiguousError
+from sirf.STIR import pTest
+from sirf.SIRF import ContiguousError
 from sirf.Utilities import runner, RE_PYEXT, examples_data_path, existing_filepath
 
 __version__ = '0.1.0'

--- a/src/xSTIR/pSTIR/tests/tests_asarray.py
+++ b/src/xSTIR/pSTIR/tests/tests_asarray.py
@@ -92,31 +92,6 @@ def test_main(rec=False, verb=False, throw=True, no_ret_val=True, \
     img_data = pet.ImageData(acq_data)
     asarray4img(img_data, test)
 
-    print('\n-- testing discontiguous image:')
-    import sirf.Gadgetron as mr
-    import os.path
-    acq_data = mr.AcquisitionData(os.path.join(data_path, '..', 'MR', 'simulated_MR_2D_cartesian.h5'))
-    preprocessed_data = mr.preprocess_acquisition_data(acq_data)
-    recon = mr.FullySampledReconstructor()
-    recon.set_input(preprocessed_data)
-    recon.process()
-    img_data = recon.get_output()
-    try:
-        test.ntest += 1
-        img_data.asarray(copy=False)
-    except ContiguousError:
-        pass
-    else:
-        test.failed = True
-        print('expected ContiguousError not raised')
-
-    try:
-        test.ntest += 1
-        img_data.asarray()
-    except Exception as e:
-        test.failed = True
-        print(e)
-
     numpy.testing.assert_equal(test.failed, 0)
     if no_ret_val:
         return


### PR DESCRIPTION
## Changes in this pull request

Removed MR tests from the `xSTIR/pSTIR/tests` directory and moved them to `xGadgetron/pGadgetron/tests/test_algebra.py`

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

- closes #1398 


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [ ] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
