### PR TITLE
tests: pass when missing torch

### DIFF
--- a/src/torch/tests/test_null.py
+++ b/src/torch/tests/test_null.py
@@ -1,0 +1,4 @@
+def test_null():
+    """dummy test; always runs regardless of whether torch is found"""
+    # work-around for https://github.com/pytest-dev/pytest/pull/817
+    pass


### PR DESCRIPTION
Allows e.g. [SuperBuild `ctest` to pass](https://github.com/SyneRBI/SIRF-SuperBuild/pull/994) without installing `torch`.