### PR TITLE
Switched to using array API for norm(), dot() and copyto()

### DIFF
--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -37,6 +37,8 @@ import deprecation
 
 from sirf.Utilities import HANDLE, assert_validities, assert_validity, cpp_int_dtype
 
+import array_api_compat as aac
+
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 4:
     ABC = abc.ABC
 else:
@@ -48,7 +50,6 @@ def norm(x):
        (numpy.ndarray or an object of a class that has method norm).
     '''
     try:
-        import array_api_compat as aac
         xp = aac.array_namespace(x)
         return xp.linalg.vector_norm(x)
     except:
@@ -62,7 +63,6 @@ def dot(x, y):
        that acts as numpy.vdot).
     '''
     try:
-        import array_api_compat as aac
         xp = aac.array_namespace(x)
         return xp.vdot(x, y)
     except:
@@ -76,7 +76,6 @@ def copyto(y, x):
        acts as numpy.copy(y, x) is defined).
     '''
     try:
-        import array_api_compat as aac
         xp = aac.array_namespace(x)
         return xp.copyto(y, x)
     except:

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -49,11 +49,10 @@ def norm(x):
     '''
     try:
         import array_api_compat as aac
-        xp = aac.array_namespace()
-        import xp.linalg
-        return xp.linalg.matrix_norm(x)
+        xp = aac.array_namespace(x)
+        return xp.linalg.vector_norm(x)
     except:
-        print('=== array_api_compat not deined, try method norm of x')
+        # array_api_compat not defined for this x, using x.norm() instead
         return x.norm()
 
 
@@ -64,11 +63,10 @@ def dot(x, y):
     '''
     try:
         import array_api_compat as aac
-        xp = aac.array_namespace()
-        import xp.linalg
-        return xp.linalg.vecdot(x, y)
+        xp = aac.array_namespace(x)
+        return xp.vdot(x, y)
     except:
-        print('=== array_api_compat not deined, try method dot of x')
+        # array_api_compat not defined for these x and/or y, using x.dot(y) instead
         return x.dot(y)
 
 
@@ -79,11 +77,10 @@ def copyto(y, x):
     '''
     try:
         import array_api_compat as aac
-        xp = aac.array_namespace()
-        import xp.linalg
-        return xp.linalg.copyto(y, x)
+        xp = aac.array_namespace(x)
+        return xp.copyto(y, x)
     except:
-        print('=== array_api_compat not deined, try method copy of y')
+        # array_api_compat not defined for these x and/or y, using y.copy(x) instead
         return y.copy(x)
 
 

--- a/src/common/SIRF.py
+++ b/src/common/SIRF.py
@@ -47,9 +47,13 @@ def norm(x):
     '''Computes the norm of x for both types of x we are using
        (numpy.ndarray or an object of a class that has method norm).
     '''
-    if isinstance(x, numpy.ndarray):
-        return numpy.linalg.norm(x)
-    else:
+    try:
+        import array_api_compat as aac
+        xp = aac.array_namespace()
+        import xp.linalg
+        return xp.linalg.matrix_norm(x)
+    except:
+        print('=== array_api_compat not deined, try method norm of x')
         return x.norm()
 
 
@@ -58,9 +62,13 @@ def dot(x, y):
        (both numpy.ndarray's or else objects of a class that has method dot
        that acts as numpy.vdot).
     '''
-    if isinstance(x, numpy.ndarray):
-        return numpy.vdot(x, y)
-    else:
+    try:
+        import array_api_compat as aac
+        xp = aac.array_namespace()
+        import xp.linalg
+        return xp.linalg.vecdot(x, y)
+    except:
+        print('=== array_api_compat not deined, try method dot of x')
         return x.dot(y)
 
 
@@ -69,9 +77,13 @@ def copyto(y, x):
        (both numpy.ndarray's or else objects for which y.copy(x) that
        acts as numpy.copy(y, x) is defined).
     '''
-    if isinstance(x, numpy.ndarray):
-        return numpy.copyto(y, x)
-    else:
+    try:
+        import array_api_compat as aac
+        xp = aac.array_namespace()
+        import xp.linalg
+        return xp.linalg.copyto(y, x)
+    except:
+        print('=== array_api_compat not deined, try method copy of y')
         return y.copy(x)
 
 


### PR DESCRIPTION
## Changes in this pull request

Switched to using array API for norm(), dot() and copyto().

## Testing performed


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Fixes #1339.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
