### PR TITLE
Add ORCiD for Matthew Strugari in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -45,6 +45,7 @@ authors:
     affiliation: University College London
   - given-names: Matthew
     family-names: Strugari
+    orcid: 'https://orcid.org/0000-0001-8045-9126'
     affiliation: Dalhousie University (Canada)
   - orcid: 'https://orcid.org/0000-0002-1815-4716'
     affiliation: University College London, National Physics Laboratory


### PR DESCRIPTION
## Changes in this pull request
Added ORCID identifier for Matthew Strugari in CITATION.cff to enable metadata propagation to Zenodo/DataCite and ORCID auto-linking in future releases. This is a minimal metadata-only change affecting citation and DOI/ORCID linkage.

## Testing performed
Validated CITATION.cff syntax locally and confirmed ORCID URL format is correct.

## Related issues
N/A

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] The code builds and runs on my machine
- [ ] CHANGES.md has been updated with any functionality change

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/SyneRBI/SIRF/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [X] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in SIRF (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.